### PR TITLE
Fixes [Add missing n8n actions to Firecrawl's n8n integration #2166](https://github.com/firecrawl/firecrawl/issues/2166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ The **Firecrawl** node supports the following operations:
 ### Crawl
 - Scrapes all the URLs of a web page and return content in LLM-ready format
 
+### Batch Scrape
+- Start a batch job to scrape multiple URLs at once
+
+### Batch Scrape Status
+- Get the status/result of a batch scrape job by ID
+
+### Batch Scrape Errors
+- Retrieve errors for a batch scrape job by ID
+
+### Crawl Active
+- List all currently active crawl jobs for your team
+
+### Crawl Params Preview
+- Preview crawl parameters generated from a natural-language prompt
+
+### Cancel Crawl
+- Cancel a running crawl job by ID
+
+### Get Crawl Errors
+- Retrieve errors for a crawl job by ID
+
 ### Get Crawl Status
 - Check the current status of a crawl job
 
@@ -41,6 +62,21 @@ The **Firecrawl** node supports the following operations:
 
 ### Get Extract Status
 - Get the current status of an extraction job
+
+### Team Token Usage
+- Get remaining and plan tokens for the authenticated team
+
+### Team Credit Usage
+- Get remaining and plan credits for the authenticated team
+
+### Historical Credit Usage
+- Get historical credit usage for your team
+
+### Historical Token Usage
+- Get historical token usage for your team
+
+### Team Queue Status
+- Get your team’s current queue load (waiting, active, max concurrency)
 
 ## Credentials
 
@@ -66,6 +102,20 @@ To use the Firecrawl node, you need to:
 * [Firecrawl API Reference](https://docs.firecrawl.dev/api-reference/introduction)
 
 ## Version history
+
+### 1.0.6
+- Add support for additional Firecrawl endpoints:
+  - Batch Scrape (start/status/errors)
+  - Crawl Active
+  - Crawl Params Preview
+  - Cancel Crawl 
+  - Get Crawl Errors
+  - Team Token Usage
+  - Team Credit Usage
+  - Historical Credit Usage
+  - Historical Token Usage
+  - Team Queue Status
+- Wire new operations into the node and align with Firecrawl API v2
 
 ### 1.0.5
 - API version updated to [/v2](https://docs.firecrawl.dev/migrate-to-v2)

--- a/nodes/Firecrawl/api/batchScrape/index.ts
+++ b/nodes/Firecrawl/api/batchScrape/index.ts
@@ -1,0 +1,128 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'batchScrape';
+export const displayName = 'Batch scrape multiple URLs';
+
+function createUrlsProperty(): INodeProperties {
+	return {
+		displayName: 'URLs',
+		name: 'urls',
+		type: 'fixedCollection',
+		default: {},
+		description: 'List of URLs to scrape',
+		options: [
+			{
+				displayName: 'URLs',
+				name: 'list',
+				values: [
+					{
+						displayName: 'URL',
+						name: 'url',
+						type: 'string',
+						default: '',
+					},
+				],
+				typeOptions: {
+					multipleValues: true,
+				},
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					urls: '={{$value.list ? $value.list.map(i => i.url) : []}}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createFormatsProperty(): INodeProperties {
+	return {
+		displayName: 'Formats',
+		name: 'formats',
+		type: 'multiOptions',
+		options: [
+			{ name: 'Markdown', value: 'markdown' },
+			{ name: 'HTML', value: 'html' },
+			{ name: 'Raw HTML', value: 'rawHtml' },
+			{ name: 'Links', value: 'links' },
+			{ name: 'Screenshot', value: 'screenshot' },
+			{ name: 'Summary', value: 'summary' },
+			{ name: 'JSON', value: 'json' },
+		],
+		default: ['markdown'],
+		description: 'Output format(s) for the scraped data',
+		routing: {
+			request: {
+				body: {
+					formats: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+			hide: {
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+function createIgnoreInvalidUrlsProperty(): INodeProperties {
+	return {
+		displayName: 'Ignore Invalid URLs',
+		name: 'ignoreInvalidURLs',
+		type: 'boolean',
+		default: true,
+		description: 'Skip invalid URLs instead of failing the entire batch',
+		routing: {
+			request: {
+				body: {
+					ignoreInvalidURLs: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+			hide: {
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+function createBatchScrapeProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name),
+		createUrlsProperty(),
+		createFormatsProperty(),
+		createIgnoreInvalidUrlsProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createBatchScrapeProperties());
+
+// Override request path to hit /batch/scrape
+options.routing = {
+	request: {
+		url: '=\/batch\/scrape',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/batchScrapeErrors/index.ts
+++ b/nodes/Firecrawl/api/batchScrapeErrors/index.ts
@@ -1,0 +1,46 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'batchScrapeErrors';
+export const displayName = 'Get batch scrape errors';
+
+function createBatchIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch ID',
+		name: 'batchId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}/errors',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name, 'GET'),
+		createBatchIdProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/batchScrapeStatus/index.ts
+++ b/nodes/Firecrawl/api/batchScrapeStatus/index.ts
@@ -1,0 +1,46 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'batchScrapeStatus';
+export const displayName = 'Get batch scrape status';
+
+function createBatchIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch ID',
+		name: 'batchId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name, 'GET'),
+		createBatchIdProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/cancelBatchScrape/index.ts
+++ b/nodes/Firecrawl/api/cancelBatchScrape/index.ts
@@ -1,0 +1,46 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'cancelBatchScrape';
+export const displayName = 'Cancel batch scrape job';
+
+function createBatchIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch ID',
+		name: 'batchId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to cancel',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name, 'DELETE'),
+		createBatchIdProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'DELETE',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/cancelCrawl/index.ts
+++ b/nodes/Firecrawl/api/cancelCrawl/index.ts
@@ -1,0 +1,46 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'cancelCrawl';
+export const displayName = 'Cancel a crawl job';
+
+function createCrawlIdProperty(): INodeProperties {
+	return {
+		displayName: 'Crawl ID',
+		name: 'crawlId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the crawl job to cancel',
+		routing: {
+			request: {
+				url: '=/crawl/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name, 'DELETE'),
+		createCrawlIdProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'DELETE',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/crawlActive/index.ts
+++ b/nodes/Firecrawl/api/crawlActive/index.ts
@@ -1,0 +1,22 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'crawlActive';
+export const displayName = 'List active crawls';
+
+function createProperties(): INodeProperties[] {
+	return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '=\/crawl\/active',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/crawlParamsPreview/index.ts
+++ b/nodes/Firecrawl/api/crawlParamsPreview/index.ts
@@ -1,0 +1,49 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice, createUrlProperty } from '../common';
+
+export const name = 'crawlParamsPreview';
+export const displayName = 'Preview crawl params from prompt';
+
+function createPromptProperty(): INodeProperties {
+	return {
+		displayName: 'Prompt',
+		name: 'prompt',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'Natural language prompt describing crawl behavior',
+		routing: {
+			request: {
+				body: {
+					prompt: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name),
+		createUrlProperty(name),
+		createPromptProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		url: '=\/crawl\/params-preview',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/creditUsageHistorical/index.ts
+++ b/nodes/Firecrawl/api/creditUsageHistorical/index.ts
@@ -1,0 +1,22 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'creditUsageHistorical';
+export const displayName = 'Get historical credit usage';
+
+function createProperties(): INodeProperties[] {
+	return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '=\/team\/credit-usage\/historical',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/getCrawlErrors/index.ts
+++ b/nodes/Firecrawl/api/getCrawlErrors/index.ts
@@ -1,0 +1,46 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'getCrawlErrors';
+export const displayName = 'Get crawl errors';
+
+function createCrawlIdProperty(): INodeProperties {
+	return {
+		displayName: 'Crawl ID',
+		name: 'crawlId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the crawl job',
+		routing: {
+			request: {
+				url: '=/crawl/{{$value}}/errors',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [name],
+			},
+		},
+	};
+}
+
+function createProperties(): INodeProperties[] {
+	return [
+		createOperationNotice('Default', name, 'GET'),
+		createCrawlIdProperty(),
+	];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/index.ts
+++ b/nodes/Firecrawl/api/index.ts
@@ -5,6 +5,13 @@ import { options as searchOptions, properties as searchProperties } from './sear
 import { options as mapOptions, properties as mapProperties } from './map';
 import { options as scrapeOptions, properties as scrapeProperties } from './scrape';
 import { options as crawlOptions, properties as crawlProperties } from './crawl';
+import { options as batchScrapeOptions, properties as batchScrapeProperties } from './batchScrape';
+import { options as batchScrapeStatusOptions, properties as batchScrapeStatusProperties } from './batchScrapeStatus';
+import { options as batchScrapeErrorsOptions, properties as batchScrapeErrorsProperties } from './batchScrapeErrors';
+import { options as crawlActiveOptions, properties as crawlActiveProperties } from './crawlActive';
+import { options as crawlParamsPreviewOptions, properties as crawlParamsPreviewProperties } from './crawlParamsPreview';
+import { options as cancelCrawlOptions, properties as cancelCrawlProperties } from './cancelCrawl';
+import { options as getCrawlErrorsOptions, properties as getCrawlErrorsProperties } from './getCrawlErrors';
 import {
 	options as getCrawlStatusOptions,
 	properties as getCrawlStatusProperties,
@@ -14,6 +21,12 @@ import {
 	options as getExtractStatusOptions,
 	properties as getExtractStatusProperties,
 } from './getExtractStatus';
+import { options as teamTokenUsageOptions, properties as teamTokenUsageProperties } from './teamTokenUsage';
+import { options as creditUsageHistoricalOptions, properties as creditUsageHistoricalProperties } from './creditUsageHistorical';
+import { options as cancelBatchScrapeOptions, properties as cancelBatchScrapeProperties } from './cancelBatchScrape';
+import { options as teamCreditUsageOptions, properties as teamCreditUsageProperties } from './teamCreditUsage';
+import { options as teamTokenUsageHistoricalOptions, properties as teamTokenUsageHistoricalProperties } from './teamTokenUsageHistorical';
+import { options as teamQueueStatusOptions, properties as teamQueueStatusProperties } from './teamQueueStatus';
 
 /**
  * Combined operation options
@@ -23,9 +36,22 @@ const operationOptions: INodePropertyOptions[] = [
 	mapOptions,
 	scrapeOptions,
 	crawlOptions,
+    batchScrapeOptions,
+    batchScrapeStatusOptions,
+    batchScrapeErrorsOptions,
+    crawlActiveOptions,
+    crawlParamsPreviewOptions,
+    cancelCrawlOptions,
+    getCrawlErrorsOptions,
+    cancelBatchScrapeOptions,
 	getCrawlStatusOptions,
 	extractOptions,
 	getExtractStatusOptions,
+    teamTokenUsageOptions,
+    teamCreditUsageOptions,
+    teamTokenUsageHistoricalOptions,
+    teamQueueStatusOptions,
+    creditUsageHistoricalOptions,
 ];
 
 /**
@@ -36,9 +62,22 @@ const rawProperties: INodeProperties[] = [
 	...mapProperties,
 	...scrapeProperties,
 	...crawlProperties,
+    ...batchScrapeProperties,
+    ...batchScrapeStatusProperties,
+    ...batchScrapeErrorsProperties,
+    ...crawlActiveProperties,
+    ...crawlParamsPreviewProperties,
+    ...cancelCrawlProperties,
+    ...getCrawlErrorsProperties,
+    ...cancelBatchScrapeProperties,
 	...getCrawlStatusProperties,
 	...extractProperties,
 	...getExtractStatusProperties,
+    ...teamTokenUsageProperties,
+    ...teamCreditUsageProperties,
+    ...teamTokenUsageHistoricalProperties,
+    ...teamQueueStatusProperties,
+    ...creditUsageHistoricalProperties,
 ];
 
 /**
@@ -93,6 +132,41 @@ export const apiMethods = {
 				return this.helpers.httpRequest as any;
 			},
 		},
+        batchScrape: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        batchScrapeStatus: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        batchScrapeErrors: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        crawlActive: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        crawlParamsPreview: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        cancelCrawl: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        getCrawlErrors: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
 		extract: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
@@ -103,5 +177,35 @@ export const apiMethods = {
 				return this.helpers.httpRequest as any;
 			},
 		},
+        teamTokenUsage: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        creditUsageHistorical: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        cancelBatchScrape: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        teamCreditUsage: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        teamTokenUsageHistorical: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
+        teamQueueStatus: {
+            execute(this: any) {
+                return this.helpers.httpRequest as any;
+            },
+        },
 	},
 };

--- a/nodes/Firecrawl/api/teamCreditUsage/index.ts
+++ b/nodes/Firecrawl/api/teamCreditUsage/index.ts
@@ -1,0 +1,22 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'teamCreditUsage';
+export const displayName = 'Get team credit usage';
+
+function createProperties(): INodeProperties[] {
+	return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '=\/team\/credit-usage',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/teamQueueStatus/index.ts
+++ b/nodes/Firecrawl/api/teamQueueStatus/index.ts
@@ -1,0 +1,22 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'teamQueueStatus';
+export const displayName = "Get team queue status";
+
+function createProperties(): INodeProperties[] {
+	return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '=\/team\/queue-status',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/teamTokenUsage/index.ts
+++ b/nodes/Firecrawl/api/teamTokenUsage/index.ts
@@ -1,0 +1,22 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'teamTokenUsage';
+export const displayName = 'Get team token usage';
+
+function createProperties(): INodeProperties[] {
+	return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '=\/team\/token-usage',
+	},
+};
+
+export { options, properties };
+
+

--- a/nodes/Firecrawl/api/teamTokenUsageHistorical/index.ts
+++ b/nodes/Firecrawl/api/teamTokenUsageHistorical/index.ts
@@ -1,0 +1,22 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'teamTokenUsageHistorical';
+export const displayName = 'Get historical team token usage';
+
+function createProperties(): INodeProperties[] {
+	return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProperties());
+
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '=\/team\/token-usage\/historical',
+	},
+};
+
+export { options, properties };
+
+


### PR DESCRIPTION
Refs : [Add missing n8n actions to Firecrawl's n8n integration #2166](https://github.com/firecrawl/firecrawl/issues/2166)

Adds full parity with publicly documented Firecrawl v2 REST endpoints in the n8n Firecrawl node.

New Operations :

- Batch Scrape: POST /v2/batch/scrape
- Batch Scrape Status: GET /v2/batch/scrape/{id}
- Batch Scrape Errors: GET /v2/batch/scrape/{id}/errors
- Cancel Batch Scrape: DELETE /v2/batch/scrape/{id}
- Crawl Active: GET /v2/crawl/active
- Crawl Params Preview: POST /v2/crawl/params-preview
- Get Crawl Errors: GET /v2/crawl/{id}/errors
- Team Credit Usage: GET /v2/team/credit-usage
- Historical Credit Usage: GET /v2/team/credit-usage/historical
- Historical Token Usage: GET /v2/team/token-usage/historical
- Team Queue Status: GET /v2/team/queue-status