### PR TITLE
Fixes #2166 - Add missing n8n actions to Firecrawl's n8n integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is an n8n community node. It lets you use **[Firecrawl](https://firecrawl.d
 [Compatibility](#compatibility)  
 [Resources](#resources)  
 [Version history](#version-history)  
+[Examples](#examples)
 
 ## Installation
 
@@ -30,17 +31,56 @@ The **Firecrawl** node supports the following operations:
 ### Scrape
 - Scrapes a URL and get its content in LLM-ready format (markdown, structured data via LLM Extract, screenshot, html)
 
+### Batch Scrape
+- Submit multiple URLs to scrape in a single request for higher throughput and simpler flows
+
 ### Crawl
 - Scrapes all the URLs of a web page and return content in LLM-ready format
 
+### Preview Crawl Params
+- Preview/validate crawl parameters without starting a crawl
+
 ### Get Crawl Status
 - Check the current status of a crawl job
+
+### Get Crawl Errors
+- Retrieve errors for a crawl job
+
+### Get Active Crawls
+- List active crawl jobs for the team
+
+### Cancel Crawl
+- Cancel an in-progress crawl job
 
 ### Extract Data
 - Get structured data from single page, multiple pages or entire websites with AI
 
 ### Get Extract Status
 - Get the current status of an extraction job
+
+### Get Batch Scrape Status
+- Check the current status of a batch scrape job
+
+### Get Batch Scrape Errors
+- Retrieve errors for a batch scrape job
+
+### Cancel Batch Scrape
+- Cancel an in-progress batch scrape job
+
+### Team Credit Usage
+- Get current team credit usage
+
+### Team Credit Usage Historical
+- Get historical credit usage data
+
+### Team Token Usage
+- Get current team token usage
+
+### Team Token Usage Historical
+- Get historical token usage data
+
+### Team Queue Status
+- Get current team queue status
 
 ## Credentials
 
@@ -65,7 +105,34 @@ To use the Firecrawl node, you need to:
 * [Firecrawl Documentation](https://firecrawl.dev/docs)
 * [Firecrawl API Reference](https://docs.firecrawl.dev/api-reference/introduction)
 
+## Examples
+
+- Batch scrape multiple URLs
+  - Add a Firecrawl node with Operation set to “Batch Scrape”.
+  - Enter a list of URLs and choose output formats (e.g., Markdown + JSON with a schema).
+  - Optionally set Max Concurrency, Ignore Invalid URLs, and a Webhook.
+  - Use “Get Batch Scrape Status” with the returned `data.id` to poll until `data.status` is `completed`.
+  - Use “Get Batch Scrape Errors” to retrieve any failed URLs if needed.
+  - Fan out the `data` payload using Item Lists for downstream processing.
+
+- Preview crawl parameters
+  - Add a Firecrawl node with Operation “Preview Crawl Params”.
+  - Configure URL, include/exclude paths, limits/delay, crawl options, and scrape options.
+  - Inspect the returned `data` to validate parameters before running a full crawl.
+
+- Team usage and status
+  - Add Firecrawl operations under Team (Credit/Token usage, Queue Status) to monitor quotas or queue health.
+  - Combine with If nodes and notifications to alert on thresholds.
+
 ## Version history
+
+### 1.1.0
+- Added support for all publicly documented endpoints missing from previous versions:
+  - Batch Scrape: POST /batch/scrape, GET /batch/scrape/{id}, GET /batch/scrape/{id}/errors, DELETE /batch/scrape/{id}
+  - Crawl: GET /crawl/{id}/errors, GET /crawl/active, POST /crawl/params-preview, DELETE /crawl/{id}
+  - Team: GET /team/credit-usage, GET /team/credit-usage/historical, GET /team/token-usage, GET /team/token-usage/historical, GET /team/queue-status
+- Output shape aligned for n8n: status/info endpoints return `data` key for smooth downstream use
+- Updated README with new operations
 
 ### 1.0.5
 - API version updated to [/v2](https://docs.firecrawl.dev/migrate-to-v2)

--- a/nodes/Firecrawl/api/batchScrape/index.ts
+++ b/nodes/Firecrawl/api/batchScrape/index.ts
@@ -1,176 +1,268 @@
+import { INodeProperties } from 'n8n-workflow';
 import {
-	INodeProperties,
-	IDataObject,
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-} from 'n8n-workflow';
-import {
-	buildApiProperties,
-	createOperationNotice,
-	createScrapeOptionsProperty,
+    buildApiProperties,
+    createOperationNotice,
+    createScrapeOptionsProperty,
+    createAdditionalFieldsProperty,
 } from '../common';
 
 // Define the operation name and display name
 export const name = 'batchScrape';
-export const displayName = 'Batch Scrape URLs';
+export const displayName = 'Batch scrape multiple URLs';
 export const operationName = 'batchScrape';
 
 /**
- * Creates the URLs property for batch scraping
- * @param operationName - The name of the operation
+ * Creates the URLs property
  * @returns The URLs property
  */
-function createUrlsProperty(operationName: string): INodeProperties {
-	return {
-		displayName: 'URLs',
-		name: 'urls',
-		type: 'string',
-		required: true,
-		typeOptions: {
-			editor: 'jsEditor',
-		},
-		default: '["https://example.com", "https://example.org"]',
-		description: 'Array of URLs to scrape',
-		routing: {
-			request: {
-				body: {
-					urls: '={{ $value }}',
-				},
-			},
-		},
-		displayOptions: {
-			show: {
-				resource: ['Default'],
-				operation: [operationName],
-			},
-		},
-	};
+function createUrlsProperty(): INodeProperties {
+    return {
+        displayName: 'URLs',
+        name: 'urls',
+        type: 'fixedCollection',
+        default: {},
+        typeOptions: {
+            multipleValues: true,
+        },
+        description: 'The URLs to scrape in a single batch request',
+        placeholder: 'Add URL',
+        options: [
+            {
+                displayName: 'Items',
+                name: 'items',
+                values: [
+                    {
+                        displayName: 'URL',
+                        name: 'url',
+                        type: 'string',
+                        default: '',
+                        placeholder: 'https://example.com/page-1',
+                        description: 'URL to scrape',
+                    },
+                ],
+            },
+        ],
+        routing: {
+            request: {
+                body: {
+                    urls: '={{$value.items ? $value.items.map(item => item.url) : []}}',
+                },
+            },
+        },
+        displayOptions: {
+            show: {
+                resource: ['Default'],
+                operation: [operationName],
+            },
+        },
+    };
 }
 
 /**
- * Creates the parsers property for batch scraping
- * @param operationName - The name of the operation
- * @returns The parsers property
+ * Creates the parsers property (e.g. pdf handling)
  */
 function createParsersProperty(operationName: string): INodeProperties {
-	return {
-		displayName: 'Parsers',
-		name: 'parsers',
-		type: 'multiOptions',
-		options: [
-			{
-				name: 'PDF',
-				value: 'pdf',
-			},
-		],
-		default: [],
-		description:
-			'Controls how PDF files are processed during scraping. When PDF parser is enabled, the PDF content is extracted and converted to markdown format, with billing based on the number of pages (1 credit per page). When disabled, the PDF file is returned in base64 encoding with a flat rate of 1 credit total.',
-		routing: {
-			request: {
-				body: {
-					parsers: '={{ $value }}',
-				},
-			},
-		},
-		displayOptions: {
-			show: {
-				resource: ['Default'],
-				operation: [operationName],
-			},
-		},
-	};
+    return {
+        displayName: 'Parsers',
+        name: 'parsers',
+        type: 'multiOptions',
+        options: [
+            {
+                name: 'PDF',
+                value: 'pdf',
+            },
+        ],
+        default: [],
+        description:
+            'Controls how PDF files are processed. When PDF is enabled, pages are extracted to markdown (1 credit per page). When disabled, PDF is returned base64-encoded (flat 1 credit).',
+        routing: {
+            request: {
+                body: {
+                    parsers: '={{ $value }}',
+                },
+            },
+        },
+        displayOptions: {
+            hide: {
+                useCustomBody: [true],
+            },
+            show: {
+                resource: ['Default'],
+                operation: [operationName],
+            },
+        },
+    };
+}
+
+function createIgnoreInvalidUrlsProperty(operationName: string): INodeProperties {
+    return {
+        displayName: 'Ignore Invalid URLs',
+        name: 'ignoreInvalidURLs',
+        type: 'boolean',
+        default: true,
+        description:
+            'Whether to ignore invalid URLs and return them under invalidURLs instead of failing the whole request',
+        routing: {
+            request: {
+                body: {
+                    ignoreInvalidURLs: '={{ $value }}',
+                },
+            },
+        },
+        displayOptions: {
+            hide: {
+                useCustomBody: [true],
+            },
+            show: {
+                resource: ['Default'],
+                operation: [operationName],
+            },
+        },
+    };
+}
+
+function createMaxConcurrencyProperty(operationName: string): INodeProperties {
+    return {
+        displayName: 'Max Concurrency',
+        name: 'maxConcurrency',
+        type: 'number',
+        typeOptions: {
+            minValue: 1,
+        },
+        default: 100,
+        description:
+            "Maximum number of concurrent scrapes. If not set, defaults to team concurrency limit.",
+        routing: {
+            request: {
+                body: {
+                    maxConcurrency: '={{ $value }}',
+                },
+            },
+        },
+        displayOptions: {
+            hide: {
+                useCustomBody: [true],
+            },
+            show: {
+                resource: ['Default'],
+                operation: [operationName],
+            },
+        },
+    };
+}
+
+function createWebhookProperty(operationName: string): INodeProperties {
+    return {
+        displayName: 'Webhook',
+        name: 'webhook',
+        type: 'fixedCollection',
+        default: {},
+        description: 'Webhook to notify on job events',
+        options: [
+            {
+                displayName: 'Settings',
+                name: 'settings',
+                values: [
+                    {
+                        displayName: 'URL',
+                        name: 'url',
+                        type: 'string',
+                        default: '',
+                        placeholder: 'https://example.com/webhook',
+                        description: 'Webhook URL to call',
+                    },
+                    {
+                        displayName: 'Headers',
+                        name: 'headers',
+                        type: 'fixedCollection',
+                        default: {},
+                        description: 'Optional headers to send with the webhook call',
+                        typeOptions: { multipleValues: true },
+                        options: [
+                            {
+                                displayName: 'Header',
+                                name: 'header',
+                                values: [
+                                    {
+                                        displayName: 'Key',
+                                        name: 'key',
+                                        type: 'string',
+                                        default: '',
+                                    },
+                                    {
+                                        displayName: 'Value',
+                                        name: 'value',
+                                        type: 'string',
+                                        default: '',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+        routing: {
+            request: {
+                body: {
+                    webhook:
+                        "={{ $value.settings ? { url: $value.settings.url, headers: ($value.settings.headers && $value.settings.headers.header) ? Object.fromEntries(($value.settings.headers.header || []).map(h => [h.key, h.value])) : undefined } : undefined }}",
+                },
+            },
+        },
+        displayOptions: {
+            hide: {
+                useCustomBody: [true],
+            },
+            show: {
+                resource: ['Default'],
+                operation: [operationName],
+            },
+        },
+    };
 }
 
 /**
  * Create additional fields property for custom data
  */
-function createAdditionalFieldsProperty(operation: string): INodeProperties {
-	return {
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add Field',
-		default: {},
-		description: 'Additional fields to send in the request body',
-		options: [
-			{
-				displayName: 'Custom Properties (JSON)',
-				name: 'customProperties',
-				type: 'json',
-				default: '{}',
-				description: 'Custom JSON properties to add to the request body',
-			},
-		],
-		routing: {
-			request: {
-				body: {
-					additionalFields: '={{ $value }}',
-				},
-			},
-			send: {
-				preSend: [
-					async function (
-						this: IExecuteSingleFunctions,
-						requestOptions: IHttpRequestOptions,
-					): Promise<IHttpRequestOptions> {
-						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
-							return requestOptions;
-						}
-
-						const body = requestOptions.body as IDataObject;
-						const additionalFields = body.additionalFields as IDataObject;
-
-						if (additionalFields) {
-							// Handle custom properties JSON
-							if (additionalFields.customProperties) {
-								try {
-									const customProps = JSON.parse(additionalFields.customProperties as string);
-									Object.assign(requestOptions.body as IDataObject, customProps);
-								} catch (error) {
-									// If JSON parsing fails, just skip
-								}
-							}
-
-							// Remove the additionalFields wrapper
-							delete body.additionalFields;
-						}
-
-						return requestOptions;
-					},
-				],
-			},
-		},
-		displayOptions: {
-			show: {
-				operation: [operation],
-				useCustomBody: [true],
-			},
-		},
-	};
-}
+// Additional Fields handled via shared helper
 
 /**
  * Create the properties for the batch scrape operation
  */
 function createBatchScrapeProperties(): INodeProperties[] {
-	return [
-		// Operation notice
-		createOperationNotice('Default', name),
+    return [
+        // Operation notice
+        createOperationNotice('Default', 'batch/scrape'),
 
-		// URLs input
-		createUrlsProperty(operationName),
+        // URLs input
+        createUrlsProperty(),
 
-		// Parsers
-		createParsersProperty(operationName),
+        // Parsers
+        createParsersProperty(operationName),
 
-		// Scrape options
-		createScrapeOptionsProperty(operationName, false),
-	];
+        // Concurrency and validation behavior
+        createMaxConcurrencyProperty(operationName),
+        createIgnoreInvalidUrlsProperty(operationName),
+
+        // Webhook
+        createWebhookProperty(operationName),
+
+        // Scrape options (same as scrape/crawl/extract)
+        createScrapeOptionsProperty(operationName, false),
+    ];
 }
 
 // Build and export the properties and options
 const { options, properties } = buildApiProperties(name, displayName, createBatchScrapeProperties());
+
+// Override endpoint to point to the batch scrape route
+options.routing = {
+    request: {
+        url: '=/batch/scrape',
+        method: 'POST',
+    },
+};
 
 // Add the additional fields property separately so it appears only when custom body is enabled
 properties.push(createAdditionalFieldsProperty(name));

--- a/nodes/Firecrawl/api/batchScrape/index.ts
+++ b/nodes/Firecrawl/api/batchScrape/index.ts
@@ -1,0 +1,178 @@
+import {
+	INodeProperties,
+	IDataObject,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
+import {
+	buildApiProperties,
+	createOperationNotice,
+	createScrapeOptionsProperty,
+} from '../common';
+
+// Define the operation name and display name
+export const name = 'batchScrape';
+export const displayName = 'Batch Scrape URLs';
+export const operationName = 'batchScrape';
+
+/**
+ * Creates the URLs property for batch scraping
+ * @param operationName - The name of the operation
+ * @returns The URLs property
+ */
+function createUrlsProperty(operationName: string): INodeProperties {
+	return {
+		displayName: 'URLs',
+		name: 'urls',
+		type: 'string',
+		required: true,
+		typeOptions: {
+			editor: 'jsEditor',
+		},
+		default: '["https://example.com", "https://example.org"]',
+		description: 'Array of URLs to scrape',
+		routing: {
+			request: {
+				body: {
+					urls: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Creates the parsers property for batch scraping
+ * @param operationName - The name of the operation
+ * @returns The parsers property
+ */
+function createParsersProperty(operationName: string): INodeProperties {
+	return {
+		displayName: 'Parsers',
+		name: 'parsers',
+		type: 'multiOptions',
+		options: [
+			{
+				name: 'PDF',
+				value: 'pdf',
+			},
+		],
+		default: [],
+		description:
+			'Controls how PDF files are processed during scraping. When PDF parser is enabled, the PDF content is extracted and converted to markdown format, with billing based on the number of pages (1 credit per page). When disabled, the PDF file is returned in base64 encoding with a flat rate of 1 credit total.',
+		routing: {
+			request: {
+				body: {
+					parsers: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create additional fields property for custom data
+ */
+function createAdditionalFieldsProperty(operation: string): INodeProperties {
+	return {
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		description: 'Additional fields to send in the request body',
+		options: [
+			{
+				displayName: 'Custom Properties (JSON)',
+				name: 'customProperties',
+				type: 'json',
+				default: '{}',
+				description: 'Custom JSON properties to add to the request body',
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					additionalFields: '={{ $value }}',
+				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+						const additionalFields = body.additionalFields as IDataObject;
+
+						if (additionalFields) {
+							// Handle custom properties JSON
+							if (additionalFields.customProperties) {
+								try {
+									const customProps = JSON.parse(additionalFields.customProperties as string);
+									Object.assign(requestOptions.body as IDataObject, customProps);
+								} catch (error) {
+									// If JSON parsing fails, just skip
+								}
+							}
+
+							// Remove the additionalFields wrapper
+							delete body.additionalFields;
+						}
+
+						return requestOptions;
+					},
+				],
+			},
+		},
+		displayOptions: {
+			show: {
+				operation: [operation],
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the batch scrape operation
+ */
+function createBatchScrapeProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name),
+
+		// URLs input
+		createUrlsProperty(operationName),
+
+		// Parsers
+		createParsersProperty(operationName),
+
+		// Scrape options
+		createScrapeOptionsProperty(operationName, false),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(name, displayName, createBatchScrapeProperties());
+
+// Add the additional fields property separately so it appears only when custom body is enabled
+properties.push(createAdditionalFieldsProperty(name));
+
+export { options, properties };

--- a/nodes/Firecrawl/api/cancelBatchScrape/index.ts
+++ b/nodes/Firecrawl/api/cancelBatchScrape/index.ts
@@ -1,0 +1,74 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'cancelBatchScrape';
+export const displayName = 'Cancel Batch Scrape';
+
+export const operationName = 'cancelBatchScrape';
+
+/**
+ * Creates the batch scrape ID property for cancellation
+ * @returns The batch scrape ID property
+ */
+function createBatchScrapeIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch Scrape ID',
+		name: 'batchScrapeId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to cancel',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the cancelBatchScrape operation
+ */
+function createCancelBatchScrapeProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'DELETE'),
+
+		// Batch Scrape ID input
+		createBatchScrapeIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createCancelBatchScrapeProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'DELETE',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/cancelCrawl/index.ts
+++ b/nodes/Firecrawl/api/cancelCrawl/index.ts
@@ -1,0 +1,56 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'cancelCrawl';
+export const displayName = 'Cancel Crawl';
+
+export const operationName = 'cancelCrawl';
+
+function createCrawlIdProperty(): INodeProperties {
+  return {
+    displayName: 'Crawl ID',
+    name: 'crawlId',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'ID of the crawl job to cancel',
+    placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+    routing: {
+      request: {
+        url: '=/crawl/{{$value}}',
+      },
+    },
+    displayOptions: {
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createCancelCrawlProperties(): INodeProperties[] {
+  return [createOperationNotice('Default', name, 'DELETE'), createCrawlIdProperty()];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createCancelCrawlProperties());
+
+options.routing = {
+  request: {
+    method: 'DELETE',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/crawl/index.ts
+++ b/nodes/Firecrawl/api/crawl/index.ts
@@ -1,14 +1,10 @@
+import { INodeProperties, IExecuteSingleFunctions, IHttpRequestOptions, IDataObject } from 'n8n-workflow';
 import {
-	INodeProperties,
-	IDataObject,
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-} from 'n8n-workflow';
-import {
-	buildApiProperties,
-	createOperationNotice,
-	createScrapeOptionsProperty,
-	createUrlProperty,
+    buildApiProperties,
+    createOperationNotice,
+    createScrapeOptionsProperty,
+    createUrlProperty,
+    createAdditionalFieldsProperty,
 } from '../common';
 
 // Define the operation name and display name
@@ -378,70 +374,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 /**
  * Create additional fields property for custom data
  */
-function createAdditionalFieldsProperty(operation: string): INodeProperties {
-	return {
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add Field',
-		default: {},
-		description: 'Additional fields to send in the request body',
-		options: [
-			{
-				displayName: 'Custom Properties (JSON)',
-				name: 'customProperties',
-				type: 'json',
-				default: '{}',
-				description: 'Custom JSON properties to add to the request body',
-			},
-		],
-		routing: {
-			request: {
-				body: {
-					additionalFields: '={{ $value }}',
-				},
-			},
-			send: {
-				preSend: [
-					async function (
-						this: IExecuteSingleFunctions,
-						requestOptions: IHttpRequestOptions,
-					): Promise<IHttpRequestOptions> {
-						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
-							return requestOptions;
-						}
-
-						const body = requestOptions.body as IDataObject;
-						const additionalFields = body.additionalFields as IDataObject;
-
-						if (additionalFields) {
-							// Handle custom properties JSON
-							if (additionalFields.customProperties) {
-								try {
-									const customProps = JSON.parse(additionalFields.customProperties as string);
-									Object.assign(requestOptions.body as IDataObject, customProps);
-								} catch (error) {
-									// If JSON parsing fails, just skip
-								}
-							}
-
-							// Remove the additionalFields wrapper
-							delete body.additionalFields;
-						}
-
-						return requestOptions;
-					},
-				],
-			},
-		},
-		displayOptions: {
-			show: {
-				operation: [operation],
-				useCustomBody: [true],
-			},
-		},
-	};
-}
+// Additional Fields handled via shared helper
 
 /**
  * Create the properties for the crawl operation

--- a/nodes/Firecrawl/api/extract/index.ts
+++ b/nodes/Firecrawl/api/extract/index.ts
@@ -1,10 +1,5 @@
-import {
-	INodeProperties,
-	IDataObject,
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-} from 'n8n-workflow';
-import { buildApiProperties, createOperationNotice, createScrapeOptionsProperty } from '../common';
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice, createScrapeOptionsProperty, createAdditionalFieldsProperty } from '../common';
 
 const name = 'extract';
 const displayName = 'Extract Data';
@@ -224,70 +219,7 @@ function createShowSourcesProperty(): INodeProperties {
 /**
  * Create additional fields property for custom data
  */
-function createAdditionalFieldsProperty(operation: string): INodeProperties {
-	return {
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add Field',
-		default: {},
-		description: 'Additional fields to send in the request body',
-		options: [
-			{
-				displayName: 'Custom Properties (JSON)',
-				name: 'customProperties',
-				type: 'json',
-				default: '{}',
-				description: 'Custom JSON properties to add to the request body',
-			},
-		],
-		routing: {
-			request: {
-				body: {
-					additionalFields: '={{ $value }}',
-				},
-			},
-			send: {
-				preSend: [
-					async function (
-						this: IExecuteSingleFunctions,
-						requestOptions: IHttpRequestOptions,
-					): Promise<IHttpRequestOptions> {
-						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
-							return requestOptions;
-						}
-
-						const body = requestOptions.body as IDataObject;
-						const additionalFields = body.additionalFields as IDataObject;
-
-						if (additionalFields) {
-							// Handle custom properties JSON
-							if (additionalFields.customProperties) {
-								try {
-									const customProps = JSON.parse(additionalFields.customProperties as string);
-									Object.assign(requestOptions.body as IDataObject, customProps);
-								} catch (error) {
-									// If JSON parsing fails, just skip
-								}
-							}
-
-							// Remove the additionalFields wrapper
-							delete body.additionalFields;
-						}
-
-						return requestOptions;
-					},
-				],
-			},
-		},
-		displayOptions: {
-			show: {
-				operation: [operation],
-				useCustomBody: [true],
-			},
-		},
-	};
-}
+// Additional Fields handled via shared helper
 
 /**
  * Creates all properties for the extract operation

--- a/nodes/Firecrawl/api/getActiveCrawls/index.ts
+++ b/nodes/Firecrawl/api/getActiveCrawls/index.ts
@@ -1,0 +1,33 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getActiveCrawls';
+export const displayName = 'Get Active Crawls';
+
+export const operationName = 'getActiveCrawls';
+
+function createGetActiveCrawlsProperties(): INodeProperties[] {
+  return [createOperationNotice('Default', name, 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createGetActiveCrawlsProperties());
+
+options.routing = {
+  request: {
+    method: 'GET',
+    url: '=/crawl/active',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/getBatchScrapeErrors/index.ts
+++ b/nodes/Firecrawl/api/getBatchScrapeErrors/index.ts
@@ -1,0 +1,74 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getBatchScrapeErrors';
+export const displayName = 'Get Batch Scrape Errors';
+
+export const operationName = 'getBatchScrapeErrors';
+
+/**
+ * Creates the batch scrape ID property for errors
+ * @returns The batch scrape ID property
+ */
+function createBatchScrapeIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch Scrape ID',
+		name: 'batchScrapeId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to get errors for',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}/errors',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the getBatchScrapeErrors operation
+ */
+function createGetBatchScrapeErrorsProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'GET'),
+
+		// Batch Scrape ID input
+		createBatchScrapeIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createGetBatchScrapeErrorsProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'GET',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/getBatchScrapeStatus/index.ts
+++ b/nodes/Firecrawl/api/getBatchScrapeStatus/index.ts
@@ -1,0 +1,74 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getBatchScrapeStatus';
+export const displayName = 'Get Batch Scrape Status';
+
+export const operationName = 'getBatchScrapeStatus';
+
+/**
+ * Creates the batch scrape ID property
+ * @returns The batch scrape ID property
+ */
+function createBatchScrapeIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch Scrape ID',
+		name: 'batchScrapeId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to get status for',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the getBatchScrapeStatus operation
+ */
+function createGetBatchScrapeStatusProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'GET'),
+
+		// Batch Scrape ID input
+		createBatchScrapeIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createGetBatchScrapeStatusProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'GET',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/getCrawlErrors/index.ts
+++ b/nodes/Firecrawl/api/getCrawlErrors/index.ts
@@ -1,0 +1,56 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getCrawlErrors';
+export const displayName = 'Get Crawl Errors';
+
+export const operationName = 'getCrawlErrors';
+
+function createCrawlIdProperty(): INodeProperties {
+  return {
+    displayName: 'Crawl ID',
+    name: 'crawlId',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'ID of the crawl job to get errors for',
+    placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+    routing: {
+      request: {
+        url: '=/crawl/{{$value}}/errors',
+      },
+    },
+    displayOptions: {
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createGetCrawlErrorsProperties(): INodeProperties[] {
+  return [createOperationNotice('Default', name, 'GET'), createCrawlIdProperty()];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createGetCrawlErrorsProperties());
+
+options.routing = {
+  request: {
+    method: 'GET',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/getTeamCreditUsage/index.ts
+++ b/nodes/Firecrawl/api/getTeamCreditUsage/index.ts
@@ -1,0 +1,32 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'getTeamCreditUsage';
+export const displayName = 'Get Team Credit Usage';
+export const operationName = 'getTeamCreditUsage';
+
+function createProps(): INodeProperties[] {
+  return [createOperationNotice('Default', 'team/credit-usage', 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProps());
+
+options.routing = {
+  request: {
+    method: 'GET',
+    url: '=/team/credit-usage',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/getTeamCreditUsageHistorical/index.ts
+++ b/nodes/Firecrawl/api/getTeamCreditUsageHistorical/index.ts
@@ -1,0 +1,32 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'getTeamCreditUsageHistorical';
+export const displayName = 'Get Team Credit Usage Historical';
+export const operationName = 'getTeamCreditUsageHistorical';
+
+function createProps(): INodeProperties[] {
+  return [createOperationNotice('Default', 'team/credit-usage/historical', 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProps());
+
+options.routing = {
+  request: {
+    method: 'GET',
+    url: '=/team/credit-usage/historical',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/getTeamQueueStatus/index.ts
+++ b/nodes/Firecrawl/api/getTeamQueueStatus/index.ts
@@ -1,0 +1,32 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'getTeamQueueStatus';
+export const displayName = 'Get Team Queue Status';
+export const operationName = 'getTeamQueueStatus';
+
+function createProps(): INodeProperties[] {
+  return [createOperationNotice('Default', 'team/queue-status', 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProps());
+
+options.routing = {
+  request: {
+    method: 'GET',
+    url: '=/team/queue-status',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/getTeamTokenUsage/index.ts
+++ b/nodes/Firecrawl/api/getTeamTokenUsage/index.ts
@@ -1,0 +1,32 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'getTeamTokenUsage';
+export const displayName = 'Get Team Token Usage';
+export const operationName = 'getTeamTokenUsage';
+
+function createProps(): INodeProperties[] {
+  return [createOperationNotice('Default', 'team/token-usage', 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProps());
+
+options.routing = {
+  request: {
+    method: 'GET',
+    url: '=/team/token-usage',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/getTeamTokenUsageHistorical/index.ts
+++ b/nodes/Firecrawl/api/getTeamTokenUsageHistorical/index.ts
@@ -1,0 +1,32 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+export const name = 'getTeamTokenUsageHistorical';
+export const displayName = 'Get Team Token Usage Historical';
+export const operationName = 'getTeamTokenUsageHistorical';
+
+function createProps(): INodeProperties[] {
+  return [createOperationNotice('Default', 'team/token-usage/historical', 'GET')];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createProps());
+
+options.routing = {
+  request: {
+    method: 'GET',
+    url: '=/team/token-usage/historical',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+

--- a/nodes/Firecrawl/api/index.ts
+++ b/nodes/Firecrawl/api/index.ts
@@ -4,6 +4,7 @@ import { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
 import { options as searchOptions, properties as searchProperties } from './search';
 import { options as mapOptions, properties as mapProperties } from './map';
 import { options as scrapeOptions, properties as scrapeProperties } from './scrape';
+import { options as batchScrapeOptions, properties as batchScrapeProperties } from './batchScrape';
 import { options as crawlOptions, properties as crawlProperties } from './crawl';
 import {
 	options as getCrawlStatusOptions,
@@ -14,6 +15,18 @@ import {
 	options as getExtractStatusOptions,
 	properties as getExtractStatusProperties,
 } from './getExtractStatus';
+import {
+	options as getBatchScrapeStatusOptions,
+	properties as getBatchScrapeStatusProperties,
+} from './getBatchScrapeStatus';
+import {
+	options as getBatchScrapeErrorsOptions,
+	properties as getBatchScrapeErrorsProperties,
+} from './getBatchScrapeErrors';
+import {
+	options as cancelBatchScrapeOptions,
+	properties as cancelBatchScrapeProperties,
+} from './cancelBatchScrape';
 
 /**
  * Combined operation options
@@ -22,10 +35,14 @@ const operationOptions: INodePropertyOptions[] = [
 	searchOptions,
 	mapOptions,
 	scrapeOptions,
+	batchScrapeOptions,
 	crawlOptions,
 	getCrawlStatusOptions,
 	extractOptions,
 	getExtractStatusOptions,
+	getBatchScrapeStatusOptions,
+	getBatchScrapeErrorsOptions,
+	cancelBatchScrapeOptions,
 ];
 
 /**
@@ -35,10 +52,14 @@ const rawProperties: INodeProperties[] = [
 	...searchProperties,
 	...mapProperties,
 	...scrapeProperties,
+	...batchScrapeProperties,
 	...crawlProperties,
 	...getCrawlStatusProperties,
 	...extractProperties,
 	...getExtractStatusProperties,
+	...getBatchScrapeStatusProperties,
+	...getBatchScrapeErrorsProperties,
+	...cancelBatchScrapeProperties,
 ];
 
 /**
@@ -83,6 +104,11 @@ export const apiMethods = {
 				return this.helpers.httpRequest as any;
 			},
 		},
+		batchScrape: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
 		crawl: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
@@ -99,6 +125,21 @@ export const apiMethods = {
 			},
 		},
 		getExtractStatus: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getBatchScrapeStatus: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getBatchScrapeErrors: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		cancelBatchScrape: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
 			},

--- a/nodes/Firecrawl/api/index.ts
+++ b/nodes/Firecrawl/api/index.ts
@@ -10,6 +10,10 @@ import {
 	options as getCrawlStatusOptions,
 	properties as getCrawlStatusProperties,
 } from './getCrawlStatus';
+import { options as getCrawlErrorsOptions, properties as getCrawlErrorsProperties } from './getCrawlErrors';
+import { options as getActiveCrawlsOptions, properties as getActiveCrawlsProperties } from './getActiveCrawls';
+import { options as previewCrawlParamsOptions, properties as previewCrawlParamsProperties } from './previewCrawlParams';
+import { options as cancelCrawlOptions, properties as cancelCrawlProperties } from './cancelCrawl';
 import { options as extractOptions, properties as extractProperties } from './extract';
 import {
 	options as getExtractStatusOptions,
@@ -27,6 +31,11 @@ import {
 	options as cancelBatchScrapeOptions,
 	properties as cancelBatchScrapeProperties,
 } from './cancelBatchScrape';
+import { options as getTeamCreditUsageOptions, properties as getTeamCreditUsageProperties } from './getTeamCreditUsage';
+import { options as getTeamCreditUsageHistoricalOptions, properties as getTeamCreditUsageHistoricalProperties } from './getTeamCreditUsageHistorical';
+import { options as getTeamQueueStatusOptions, properties as getTeamQueueStatusProperties } from './getTeamQueueStatus';
+import { options as getTeamTokenUsageOptions, properties as getTeamTokenUsageProperties } from './getTeamTokenUsage';
+import { options as getTeamTokenUsageHistoricalOptions, properties as getTeamTokenUsageHistoricalProperties } from './getTeamTokenUsageHistorical';
 
 /**
  * Combined operation options
@@ -38,11 +47,20 @@ const operationOptions: INodePropertyOptions[] = [
 	batchScrapeOptions,
 	crawlOptions,
 	getCrawlStatusOptions,
+	getCrawlErrorsOptions,
+	getActiveCrawlsOptions,
+	previewCrawlParamsOptions,
+	cancelCrawlOptions,
 	extractOptions,
 	getExtractStatusOptions,
 	getBatchScrapeStatusOptions,
 	getBatchScrapeErrorsOptions,
 	cancelBatchScrapeOptions,
+	getTeamCreditUsageOptions,
+	getTeamCreditUsageHistoricalOptions,
+	getTeamQueueStatusOptions,
+	getTeamTokenUsageOptions,
+	getTeamTokenUsageHistoricalOptions,
 ];
 
 /**
@@ -55,11 +73,20 @@ const rawProperties: INodeProperties[] = [
 	...batchScrapeProperties,
 	...crawlProperties,
 	...getCrawlStatusProperties,
+	...getCrawlErrorsProperties,
+	...getActiveCrawlsProperties,
+	...previewCrawlParamsProperties,
+	...cancelCrawlProperties,
 	...extractProperties,
 	...getExtractStatusProperties,
 	...getBatchScrapeStatusProperties,
 	...getBatchScrapeErrorsProperties,
 	...cancelBatchScrapeProperties,
+	...getTeamCreditUsageProperties,
+	...getTeamCreditUsageHistoricalProperties,
+	...getTeamQueueStatusProperties,
+	...getTeamTokenUsageProperties,
+	...getTeamTokenUsageHistoricalProperties,
 ];
 
 /**
@@ -119,6 +146,26 @@ export const apiMethods = {
 				return this.helpers.httpRequest as any;
 			},
 		},
+		getCrawlErrors: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getActiveCrawls: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		previewCrawlParams: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		cancelCrawl: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
 		extract: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
@@ -140,6 +187,31 @@ export const apiMethods = {
 			},
 		},
 		cancelBatchScrape: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getTeamCreditUsage: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getTeamCreditUsageHistorical: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getTeamQueueStatus: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getTeamTokenUsage: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getTeamTokenUsageHistorical: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
 			},

--- a/nodes/Firecrawl/api/map/index.ts
+++ b/nodes/Firecrawl/api/map/index.ts
@@ -1,10 +1,5 @@
-import {
-	INodeProperties,
-	IDataObject,
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-} from 'n8n-workflow';
-import { buildApiProperties, createOperationNotice, createUrlProperty } from '../common';
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice, createUrlProperty, createAdditionalFieldsProperty } from '../common';
 
 // Define the operation name and display name
 export const name = 'map';
@@ -141,70 +136,7 @@ function createTimeoutProperty(): INodeProperties {
 /**
  * Create additional fields property for custom data
  */
-function createAdditionalFieldsProperty(operation: string): INodeProperties {
-	return {
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add Field',
-		default: {},
-		description: 'Additional fields to send in the request body',
-		options: [
-			{
-				displayName: 'Custom Properties (JSON)',
-				name: 'customProperties',
-				type: 'json',
-				default: '{}',
-				description: 'Custom JSON properties to add to the request body',
-			},
-		],
-		routing: {
-			request: {
-				body: {
-					additionalFields: '={{ $value }}',
-				},
-			},
-			send: {
-				preSend: [
-					async function (
-						this: IExecuteSingleFunctions,
-						requestOptions: IHttpRequestOptions,
-					): Promise<IHttpRequestOptions> {
-						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
-							return requestOptions;
-						}
-
-						const body = requestOptions.body as IDataObject;
-						const additionalFields = body.additionalFields as IDataObject;
-
-						if (additionalFields) {
-							// Handle custom properties JSON
-							if (additionalFields.customProperties) {
-								try {
-									const customProps = JSON.parse(additionalFields.customProperties as string);
-									Object.assign(requestOptions.body as IDataObject, customProps);
-								} catch (error) {
-									// If JSON parsing fails, just skip
-								}
-							}
-
-							// Remove the additionalFields wrapper
-							delete body.additionalFields;
-						}
-
-						return requestOptions;
-					},
-				],
-			},
-		},
-		displayOptions: {
-			show: {
-				operation: [operation],
-				useCustomBody: [true],
-			},
-		},
-	};
-}
+// Additional Fields handled via shared helper
 
 /**
  * Create the properties for the map operation

--- a/nodes/Firecrawl/api/previewCrawlParams/index.ts
+++ b/nodes/Firecrawl/api/previewCrawlParams/index.ts
@@ -1,0 +1,306 @@
+import { INodeProperties } from 'n8n-workflow';
+import {
+  buildApiProperties,
+  createOperationNotice,
+  createUrlProperty,
+  createScrapeOptionsProperty,
+  createAdditionalFieldsProperty,
+} from '../common';
+
+// Define the operation name and display name
+export const name = 'previewCrawlParams';
+export const displayName = 'Preview Crawl Params';
+
+export const operationName = 'previewCrawlParams';
+
+function createPreviewCrawlParamsProperties(): INodeProperties[] {
+  return [
+    createOperationNotice('Default', name),
+    createUrlProperty(operationName, 'https://firecrawl.dev'),
+    // Reuse scrape options to allow shaping what will be previewed
+    createScrapeOptionsProperty(operationName),
+    // Prompt
+    createPromptProperty(operationName),
+    // Limit / Delay / Max Concurrency
+    createLimitProperty(operationName),
+    createDelayProperty(operationName),
+    createMaxConcurrencyProperty(operationName),
+    // Include/Exclude paths
+    createExcludePathsProperty(operationName),
+    createIncludePathsProperty(operationName),
+    // Crawl options (subset)
+    createCrawlOptionsProperty(operationName),
+  ];
+}
+
+const { options, properties } = buildApiProperties(name, displayName, createPreviewCrawlParamsProperties());
+
+options.routing = {
+  request: {
+    method: 'POST',
+    url: '=/crawl/params-preview',
+  },
+  output: {
+    postReceive: [
+      {
+        type: 'setKeyValue',
+        properties: {
+          data: '={{$response.body}}',
+        },
+      },
+    ],
+  },
+};
+
+export { options, properties };
+
+// Allow additional custom JSON when Use Custom Body is enabled
+properties.push(createAdditionalFieldsProperty(name));
+
+/** Below are helpers modeled after the Crawl operation to match parity **/
+
+function createPromptProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Prompt',
+    name: 'prompt',
+    type: 'string',
+    default: '',
+    description: 'Prompt to use for the crawl',
+    routing: {
+      request: {
+        body: {
+          prompt: '={{ $value }}',
+        },
+      },
+    },
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createLimitProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Limit',
+    name: 'limit',
+    type: 'number',
+    typeOptions: { minValue: 1 },
+    // eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-limit
+    default: 500,
+    description: 'Max number of results to return',
+    routing: {
+      request: {
+        body: {
+          limit: '={{ $value }}',
+        },
+      },
+    },
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createDelayProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Delay',
+    name: 'delay',
+    type: 'number',
+    typeOptions: { minValue: 0 },
+    default: 0,
+    description: 'Delay between requests in milliseconds',
+    routing: {
+      request: {
+        body: {
+          delay: '={{ $value }}',
+        },
+      },
+    },
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createMaxConcurrencyProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Max Concurrency',
+    name: 'maxConcurrency',
+    type: 'number',
+    typeOptions: { minValue: 1 },
+    default: 100,
+    description:
+      "Maximum number of concurrent scrapes. If not specified, adheres to team's concurrency limit.",
+    routing: {
+      request: {
+        body: {
+          maxConcurrency: '={{ $value }}',
+        },
+      },
+    },
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createExcludePathsProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Exclude Paths',
+    name: 'excludePaths',
+    type: 'fixedCollection',
+    default: [],
+    typeOptions: { multipleValues: true },
+    description:
+      'URL path patterns to exclude (e.g., blog/* excludes /blog/article-1)',
+    placeholder: 'Add path to exclude',
+    options: [
+      {
+        displayName: 'Items',
+        name: 'items',
+        values: [
+          {
+            displayName: 'Path',
+            name: 'path',
+            type: 'string',
+            default: '',
+            placeholder: 'blog/*',
+          },
+        ],
+      },
+    ],
+    routing: {
+      request: {
+        body: {
+          excludePaths: '={{$value.items.map(item => item.path)}}',
+        },
+      },
+    },
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createIncludePathsProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Include Paths',
+    name: 'includePaths',
+    type: 'fixedCollection',
+    default: [],
+    typeOptions: { multipleValues: true },
+    description:
+      'URL path patterns to include (e.g., blog/* includes paths like /blog/article-1)',
+    placeholder: 'Add path to include',
+    options: [
+      {
+        displayName: 'Items',
+        name: 'items',
+        values: [
+          {
+            displayName: 'Path',
+            name: 'path',
+            type: 'string',
+            default: '',
+            placeholder: 'blog/*',
+          },
+        ],
+      },
+    ],
+    routing: {
+      request: {
+        body: {
+          includePaths: '={{$value.items.map(item => item.path)}}',
+        },
+      },
+    },
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}
+
+function createCrawlOptionsProperty(operationName: string): INodeProperties {
+  return {
+    displayName: 'Crawl Options',
+    name: 'crawlOptions',
+    type: 'collection',
+    placeholder: 'Add Option',
+    default: {},
+    options: [
+      {
+        displayName: 'Ignore Sitemap',
+        name: 'ignoreSitemap',
+        type: 'boolean',
+        default: false,
+        routing: { request: { body: { ignoreSitemap: '={{ $value }}' } } },
+      },
+      {
+        displayName: 'Ignore Query Params',
+        name: 'ignoreQueryParameters',
+        type: 'boolean',
+        default: false,
+        routing: { request: { body: { ignoreQueryParameters: '={{ $value }}' } } },
+      },
+      {
+        displayName: 'Allow External Links',
+        name: 'allowExternalLinks',
+        type: 'boolean',
+        default: false,
+        routing: { request: { body: { allowExternalLinks: '={{ $value }}' } } },
+      },
+      {
+        displayName: 'Allow Subdomains',
+        name: 'allowSubdomains',
+        type: 'boolean',
+        default: false,
+        routing: { request: { body: { allowSubdomains: '={{ $value }}' } } },
+      },
+    ],
+    displayOptions: {
+      hide: {
+        useCustomBody: [true],
+      },
+      show: {
+        resource: ['Default'],
+        operation: [operationName],
+      },
+    },
+  };
+}

--- a/nodes/Firecrawl/api/scrape/index.ts
+++ b/nodes/Firecrawl/api/scrape/index.ts
@@ -1,14 +1,10 @@
+import { INodeProperties } from 'n8n-workflow';
 import {
-	INodeProperties,
-	IDataObject,
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-} from 'n8n-workflow';
-import {
-	buildApiProperties,
-	createOperationNotice,
-	createScrapeOptionsProperty,
-	createUrlProperty,
+    buildApiProperties,
+    createOperationNotice,
+    createScrapeOptionsProperty,
+    createUrlProperty,
+    createAdditionalFieldsProperty,
 } from '../common';
 
 // Define the operation name and display name
@@ -57,70 +53,7 @@ function createParsersProperty(operationName: string): INodeProperties {
 /**
  * Create additional fields property for custom data
  */
-function createAdditionalFieldsProperty(operation: string): INodeProperties {
-	return {
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add Field',
-		default: {},
-		description: 'Additional fields to send in the request body',
-		options: [
-			{
-				displayName: 'Custom Properties (JSON)',
-				name: 'customProperties',
-				type: 'json',
-				default: '{}',
-				description: 'Custom JSON properties to add to the request body',
-			},
-		],
-		routing: {
-			request: {
-				body: {
-					additionalFields: '={{ $value }}',
-				},
-			},
-			send: {
-				preSend: [
-					async function (
-						this: IExecuteSingleFunctions,
-						requestOptions: IHttpRequestOptions,
-					): Promise<IHttpRequestOptions> {
-						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
-							return requestOptions;
-						}
-
-						const body = requestOptions.body as IDataObject;
-						const additionalFields = body.additionalFields as IDataObject;
-
-						if (additionalFields) {
-							// Handle custom properties JSON
-							if (additionalFields.customProperties) {
-								try {
-									const customProps = JSON.parse(additionalFields.customProperties as string);
-									Object.assign(requestOptions.body as IDataObject, customProps);
-								} catch (error) {
-									// If JSON parsing fails, just skip
-								}
-							}
-
-							// Remove the additionalFields wrapper
-							delete body.additionalFields;
-						}
-
-						return requestOptions;
-					},
-				],
-			},
-		},
-		displayOptions: {
-			show: {
-				operation: [operation],
-				useCustomBody: [true],
-			},
-		},
-	};
-}
+// Additional Fields handled via shared helper
 
 /**
  * Create the properties for the scrape operation

--- a/nodes/Firecrawl/api/search/index.ts
+++ b/nodes/Firecrawl/api/search/index.ts
@@ -1,11 +1,5 @@
-import {
-	INodeProperties,
-	IDataObject,
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-} from 'n8n-workflow';
-import { buildApiProperties } from '../common';
-import { createOperationNotice } from '../common';
+import { INodeProperties, IExecuteSingleFunctions, IHttpRequestOptions, IDataObject } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice, createAdditionalFieldsProperty } from '../common';
 
 // Define the operation name and display name
 export const name = 'search';
@@ -173,70 +167,7 @@ function createTimeBasedSearchProperty(operation: string): INodeProperties {
 /**
  * Create additional fields property for custom data
  */
-function createAdditionalFieldsProperty(operationName: string): INodeProperties {
-	return {
-		displayName: 'Additional Fields',
-		name: 'additionalFields',
-		type: 'collection',
-		placeholder: 'Add Field',
-		default: {},
-		description: 'Additional fields to send in the request body',
-		options: [
-			{
-				displayName: 'Custom Properties (JSON)',
-				name: 'customProperties',
-				type: 'json',
-				default: '{}',
-				description: 'Custom JSON properties to add to the request body',
-			},
-		],
-		routing: {
-			request: {
-				body: {
-					additionalFields: '={{ $value }}',
-				},
-			},
-			send: {
-				preSend: [
-					async function (
-						this: IExecuteSingleFunctions,
-						requestOptions: IHttpRequestOptions,
-					): Promise<IHttpRequestOptions> {
-						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
-							return requestOptions;
-						}
-
-						const body = requestOptions.body as IDataObject;
-						const additionalFields = body.additionalFields as IDataObject;
-
-						if (additionalFields) {
-							// Handle custom properties JSON
-							if (additionalFields.customProperties) {
-								try {
-									const customProps = JSON.parse(additionalFields.customProperties as string);
-									Object.assign(requestOptions.body as IDataObject, customProps);
-								} catch (error) {
-									// If JSON parsing fails, just skip
-								}
-							}
-
-							// Remove the additionalFields wrapper
-							delete body.additionalFields;
-						}
-
-						return requestOptions;
-					},
-				],
-			},
-		},
-		displayOptions: {
-			show: {
-				operation: [operationName],
-				useCustomBody: [true],
-			},
-		},
-	};
-}
+// Additional Fields handled via shared helper
 
 function createTimeoutProperty(operationName: string): INodeProperties {
 	return {

--- a/nodes/Firecrawl/methods.ts
+++ b/nodes/Firecrawl/methods.ts
@@ -8,13 +8,14 @@ import { apiMethods } from './api';
  * Methods are organized by their respective API operations and
  * include functionality for handling HTTP requests and responses.
  *
- * Currently includes:
- * - API methods for map operations
- * - API methods for scrape operations
- * - API methods for crawl operations
- * - API methods for getCrawlStatus operations
- * - API methods for extract operations
- * - API methods for getExtractStatus operations
+ * Currently includes API methods for:
+ * - Search
+ * - Map
+ * - Scrape
+ * - Crawl (submit, status, errors, active, params preview, cancel)
+ * - Extract (submit, status)
+ * - Batch Scrape (submit, status, errors, cancel)
+ * - Team (credit usage, credit usage historical, token usage, token usage historical, queue status)
  *
  * @returns The combined methods object that implements INodeType['methods']
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Firecrawl node for n8n",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
- Context
          - This PR adds support for all publicly documented Firecrawl endpoints missing from the current n8n node to improve automation and reduce looping nodes (see #2166).
- Changes
          - Batch Scrape
              - POST /batch/scrape
              - GET /batch/scrape/{id}
              - GET /batch/scrape/{id}/errors
              - DELETE /batch/scrape/{id}
              - Adds Parsers, Max Concurrency, Ignore Invalid URLs, Webhook inputs
          - Crawl
              - GET /crawl/{id}/errors
              - GET /crawl/active
              - POST /crawl/params-preview
              - DELETE /crawl/{id}
          - Extract/Search/Map/Scrape
              - Existing operations retained; output shape unchanged
          - Team
              - GET /team/credit-usage
              - GET /team/credit-usage/historical
              - GET /team/token-usage
              - GET /team/token-usage/historical
              - GET /team/queue-status
          - Refactor/UX
              - Shared Additional Fields (Custom JSON) helper to merge arbitrary body when “Use Custom Body” is enabled
              - Preview Crawl Params now exposes prompt, include/exclude paths, limits/delay/concurrency, crawl/scrape options
              - Batch Scrape exposes key batch parameters explicitly
          - Documentation
              - README: new operations + practical examples
              - Version: bump to 1.1.0
- Output Shape
          - Status/info endpoints return a single item with data set to the raw response body (consistent with existing status
  nodes)
          - Content endpoints return the response JSON directly
- Testing
          - Build (tsc) and lint (eslint) pass locally
          - Verified endpoint list against docs.firecrawl.dev
- Backwards Compatibility
          - Additive only; no breaking changes; existing operations and outputs preserved
- Checklist
          - [x] Implements missing public endpoints
          - [x] Outputs are n8n-friendly
          - [x] README updated
          - [x] Build + lint clean
- Branch
      - feat/firecrawl-missing-endpoints (pushed)