### PR TITLE
feat: add missing Firecrawl n8n operations for batch processing

### DIFF
--- a/nodes/Firecrawl/api/batchScrape/index.ts
+++ b/nodes/Firecrawl/api/batchScrape/index.ts
@@ -1,0 +1,251 @@
+import {
+	INodeProperties,
+	IDataObject,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
+import {
+	buildApiProperties,
+	createOperationNotice,
+	createScrapeOptionsProperty,
+} from '../common';
+
+// Define the operation name and display name
+export const name = 'batchScrape';
+export const displayName = 'Batch Scrape URLs';
+export const operationName = 'batchScrape';
+
+/**
+ * Creates the URLs property for batch scraping
+ * @returns The URLs property
+ */
+function createUrlsProperty(): INodeProperties {
+	return {
+		displayName: 'URLs',
+		name: 'urls',
+		type: 'fixedCollection',
+		default: {},
+		typeOptions: {
+			multipleValues: true,
+		},
+		description: 'The URLs to scrape in batch. Provide multiple URLs for efficient batch processing.',
+		placeholder: 'Add URL',
+		options: [
+			{
+				displayName: 'Items',
+				name: 'items',
+				values: [
+					{
+						displayName: 'URL',
+						name: 'url',
+						type: 'string',
+						default: '',
+						placeholder: 'https://example.com',
+						description: 'URL to scrape',
+						required: true,
+					},
+				],
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					urls: '={{$value.items ? $value.items.map(item => item.url) : []}}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+			hide: {
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
+ * Creates the webhook property
+ * @returns The webhook property
+ */
+function createWebhookProperty(): INodeProperties {
+	return {
+		displayName: 'Webhook URL',
+		name: 'webhook',
+		type: 'string',
+		default: '',
+		description: 'Optional webhook URL to receive notifications when batch scraping is complete',
+		routing: {
+			request: {
+				body: {
+					webhook: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+			hide: {
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
+ * Creates the parsers property
+ * @param operationName - The name of the operation
+ * @returns The parsers property
+ */
+function createParsersProperty(operationName: string): INodeProperties {
+	return {
+		displayName: 'Parsers',
+		name: 'parsers',
+		type: 'multiOptions',
+		options: [
+			{
+				name: 'PDF',
+				value: 'pdf',
+			},
+		],
+		default: [],
+		description:
+			'Controls how PDF files are processed during scraping. When PDF parser is enabled, the PDF content is extracted and converted to markdown format, with billing based on the number of pages (1 credit per page). When disabled, the PDF file is returned in base64 encoding with a flat rate of 1 credit total.',
+		routing: {
+			request: {
+				body: {
+					parsers: '={{ $value }}',
+				},
+			},
+		},
+		displayOptions: {
+			hide: {
+				useCustomBody: [true],
+			},
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create additional fields property for custom data
+ */
+function createAdditionalFieldsProperty(operation: string): INodeProperties {
+	return {
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		description: 'Additional fields to send in the request body',
+		options: [
+			{
+				displayName: 'Custom Properties (JSON)',
+				name: 'customProperties',
+				type: 'json',
+				default: '{}',
+				description: 'Custom JSON properties to add to the request body',
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					additionalFields: '={{ $value }}',
+				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+						const additionalFields = body.additionalFields as IDataObject;
+
+						if (additionalFields) {
+							// Handle custom properties JSON
+							if (additionalFields.customProperties) {
+								try {
+									const customProps = JSON.parse(additionalFields.customProperties as string);
+									Object.assign(requestOptions.body as IDataObject, customProps);
+								} catch (error) {
+									// If JSON parsing fails, just skip
+								}
+							}
+
+							// Remove the additionalFields wrapper
+							delete body.additionalFields;
+						}
+
+						return requestOptions;
+					},
+				],
+			},
+		},
+		displayOptions: {
+			show: {
+				operation: [operation],
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the batch scrape operation
+ */
+function createBatchScrapeProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name),
+
+		// URLs input
+		createUrlsProperty(),
+
+		// Webhook
+		createWebhookProperty(),
+
+		// Parsers
+		createParsersProperty(operationName),
+
+		// Scrape options
+		createScrapeOptionsProperty(operationName, false),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(name, displayName, createBatchScrapeProperties());
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'POST',
+		url: '/batch/scrape',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+// Add the additional fields property separately so it appears only when custom body is enabled
+properties.push(createAdditionalFieldsProperty(name));
+
+export { options, properties };

--- a/nodes/Firecrawl/api/cancelBatchScrape/index.ts
+++ b/nodes/Firecrawl/api/cancelBatchScrape/index.ts
@@ -1,0 +1,75 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'cancelBatchScrape';
+export const displayName = 'Cancel batch scrape';
+
+export const operationName = 'cancelBatchScrape';
+
+/**
+ * Creates the batch scrape ID property
+ * @returns The batch scrape ID property
+ */
+function createBatchScrapeIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch Scrape ID',
+		name: 'batchScrapeId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to cancel',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the cancelBatchScrape operation
+ */
+function createCancelBatchScrapeProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'DELETE'),
+
+		// Batch Scrape ID input
+		createBatchScrapeIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createCancelBatchScrapeProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'DELETE',
+		url: '/batch/scrape/{{$parameter.batchScrapeId}}',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/cancelCrawl/index.ts
+++ b/nodes/Firecrawl/api/cancelCrawl/index.ts
@@ -1,0 +1,75 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'cancelCrawl';
+export const displayName = 'Cancel crawl';
+
+export const operationName = 'cancelCrawl';
+
+/**
+ * Creates the crawl ID property
+ * @returns The crawl ID property
+ */
+function createCrawlIdProperty(): INodeProperties {
+	return {
+		displayName: 'Crawl ID',
+		name: 'crawlId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the crawl job to cancel',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/crawl/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the cancelCrawl operation
+ */
+function createCancelCrawlProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'DELETE'),
+
+		// Crawl ID input
+		createCrawlIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createCancelCrawlProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'DELETE',
+		url: '/crawl/{{$parameter.crawlId}}',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/getBatchScrapeErrors/index.ts
+++ b/nodes/Firecrawl/api/getBatchScrapeErrors/index.ts
@@ -1,0 +1,75 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getBatchScrapeErrors';
+export const displayName = 'Get batch scrape errors';
+
+export const operationName = 'getBatchScrapeErrors';
+
+/**
+ * Creates the batch scrape ID property
+ * @returns The batch scrape ID property
+ */
+function createBatchScrapeIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch Scrape ID',
+		name: 'batchScrapeId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to get errors for',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}/errors',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the getBatchScrapeErrors operation
+ */
+function createGetBatchScrapeErrorsProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'GET'),
+
+		// Batch Scrape ID input
+		createBatchScrapeIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createGetBatchScrapeErrorsProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '/batch/scrape/{{$parameter.batchScrapeId}}/errors',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/getBatchScrapeStatus/index.ts
+++ b/nodes/Firecrawl/api/getBatchScrapeStatus/index.ts
@@ -1,0 +1,75 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getBatchScrapeStatus';
+export const displayName = 'Get batch scrape status';
+
+export const operationName = 'getBatchScrapeStatus';
+
+/**
+ * Creates the batch scrape ID property
+ * @returns The batch scrape ID property
+ */
+function createBatchScrapeIdProperty(): INodeProperties {
+	return {
+		displayName: 'Batch Scrape ID',
+		name: 'batchScrapeId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the batch scrape job to get status for',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/batch/scrape/{{$value}}',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the getBatchScrapeStatus operation
+ */
+function createGetBatchScrapeStatusProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'GET'),
+
+		// Batch Scrape ID input
+		createBatchScrapeIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createGetBatchScrapeStatusProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '/batch/scrape/{{$parameter.batchScrapeId}}',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/getCrawlErrors/index.ts
+++ b/nodes/Firecrawl/api/getCrawlErrors/index.ts
@@ -1,0 +1,75 @@
+import { INodeProperties } from 'n8n-workflow';
+import { buildApiProperties, createOperationNotice } from '../common';
+
+// Define the operation name and display name
+export const name = 'getCrawlErrors';
+export const displayName = 'Get crawl errors';
+
+export const operationName = 'getCrawlErrors';
+
+/**
+ * Creates the crawl ID property
+ * @returns The crawl ID property
+ */
+function createCrawlIdProperty(): INodeProperties {
+	return {
+		displayName: 'Crawl ID',
+		name: 'crawlId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'ID of the crawl job to get errors for',
+		placeholder: '1234abcd-5678-efgh-9012-ijklmnopqrst',
+		routing: {
+			request: {
+				url: '=/crawl/{{$value}}/errors',
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['Default'],
+				operation: [operationName],
+			},
+		},
+	};
+}
+
+/**
+ * Create the properties for the getCrawlErrors operation
+ */
+function createGetCrawlErrorsProperties(): INodeProperties[] {
+	return [
+		// Operation notice
+		createOperationNotice('Default', name, 'GET'),
+
+		// Crawl ID input
+		createCrawlIdProperty(),
+	];
+}
+
+// Build and export the properties and options
+const { options, properties } = buildApiProperties(
+	name,
+	displayName,
+	createGetCrawlErrorsProperties(),
+);
+
+// Override the default routing for this operation
+options.routing = {
+	request: {
+		method: 'GET',
+		url: '/crawl/{{$parameter.crawlId}}/errors',
+	},
+	output: {
+		postReceive: [
+			{
+				type: 'setKeyValue',
+				properties: {
+					data: '={{$response.body}}',
+				},
+			},
+		],
+	},
+};
+
+export { options, properties };

--- a/nodes/Firecrawl/api/index.ts
+++ b/nodes/Firecrawl/api/index.ts
@@ -14,6 +14,24 @@ import {
 	options as getExtractStatusOptions,
 	properties as getExtractStatusProperties,
 } from './getExtractStatus';
+import { options as batchScrapeOptions, properties as batchScrapeProperties } from './batchScrape';
+import {
+	options as getBatchScrapeStatusOptions,
+	properties as getBatchScrapeStatusProperties,
+} from './getBatchScrapeStatus';
+import {
+	options as cancelBatchScrapeOptions,
+	properties as cancelBatchScrapeProperties,
+} from './cancelBatchScrape';
+import {
+	options as getBatchScrapeErrorsOptions,
+	properties as getBatchScrapeErrorsProperties,
+} from './getBatchScrapeErrors';
+import { options as cancelCrawlOptions, properties as cancelCrawlProperties } from './cancelCrawl';
+import {
+	options as getCrawlErrorsOptions,
+	properties as getCrawlErrorsProperties,
+} from './getCrawlErrors';
 
 /**
  * Combined operation options
@@ -22,8 +40,14 @@ const operationOptions: INodePropertyOptions[] = [
 	searchOptions,
 	mapOptions,
 	scrapeOptions,
+	batchScrapeOptions,
+	getBatchScrapeStatusOptions,
+	cancelBatchScrapeOptions,
+	getBatchScrapeErrorsOptions,
 	crawlOptions,
 	getCrawlStatusOptions,
+	cancelCrawlOptions,
+	getCrawlErrorsOptions,
 	extractOptions,
 	getExtractStatusOptions,
 ];
@@ -35,8 +59,14 @@ const rawProperties: INodeProperties[] = [
 	...searchProperties,
 	...mapProperties,
 	...scrapeProperties,
+	...batchScrapeProperties,
+	...getBatchScrapeStatusProperties,
+	...cancelBatchScrapeProperties,
+	...getBatchScrapeErrorsProperties,
 	...crawlProperties,
 	...getCrawlStatusProperties,
+	...cancelCrawlProperties,
+	...getCrawlErrorsProperties,
 	...extractProperties,
 	...getExtractStatusProperties,
 ];
@@ -83,12 +113,42 @@ export const apiMethods = {
 				return this.helpers.httpRequest as any;
 			},
 		},
+		batchScrape: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getBatchScrapeStatus: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		cancelBatchScrape: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getBatchScrapeErrors: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
 		crawl: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
 			},
 		},
 		getCrawlStatus: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		cancelCrawl: {
+			execute(this: any) {
+				return this.helpers.httpRequest as any;
+			},
+		},
+		getCrawlErrors: {
 			execute(this: any) {
 				return this.helpers.httpRequest as any;
 			},

--- a/nodes/Firecrawl/properties.ts
+++ b/nodes/Firecrawl/properties.ts
@@ -164,6 +164,46 @@ export const extraProperties: INodeProperties[] = [
 ];
 
 /**
+ * Custom body for batch scrape operation
+ */
+const customBodyBatchScrape: INodeProperties = {
+	displayName: 'Custom Body',
+	name: 'customBody',
+	type: 'json',
+	default: `{
+  "urls": [
+    "https://firecrawl.dev",
+    "https://firecrawl.dev/features"
+  ],
+  "webhook": "",
+  "scrapeOptions": {
+    "formats": [
+      {
+        "type": "markdown"
+      }
+    ],
+    "onlyMainContent": true,
+    "removeBase64Images": true,
+    "mobile": false,
+    "waitFor": 0
+  }
+}`,
+	description: 'Custom body to send',
+	routing: {
+		request: {
+			body: '={{JSON.parse($value)}}',
+		},
+	},
+	displayOptions: {
+		show: {
+			resource: ['Default'],
+			operation: ['Batch Scrape URLs'],
+			useCustomBody: [true],
+		},
+	},
+};
+
+/**
  * Custom body for crawl operation
  */
 const customBodyCrawl: INodeProperties = {
@@ -217,5 +257,6 @@ export const allProperties = [
 	...resourceSelect,
 	...apiProperties,
 	...extraProperties,
+	customBodyBatchScrape,
 	customBodyCrawl,
 ];


### PR DESCRIPTION
This pull request adds several new API operations to the Firecrawl node, focusing on batch scraping and improved job management. The main changes include support for batch scraping URLs, canceling jobs, and retrieving job statuses and errors. These updates enhance the node's flexibility and robustness for handling large-scale scraping workflows.

### New batch scraping and job management operations

* Added a new `batchScrape` operation for scraping multiple URLs in a single request, including options for webhook notifications, parser selection, and custom request fields. (`nodes/Firecrawl/api/batchScrape/index.ts`, [nodes/Firecrawl/api/batchScrape/index.tsR1-R251](diffhunk://#diff-f94a1febc9247d74f83609ca549c11469df125fe204b34fe5ebe5d37d2406c4fR1-R251))
* Introduced operations to get batch scrape status (`getBatchScrapeStatus`), cancel batch scrape jobs (`cancelBatchScrape`), and retrieve batch scrape errors (`getBatchScrapeErrors`). (`nodes/Firecrawl/api/getBatchScrapeStatus/index.ts`, [[1]](diffhunk://#diff-17a3eb1317e5aae969e2bb1457d497fd627f69f6ba6fb4b201b8061d889d30bcR1-R75); `nodes/Firecrawl/api/cancelBatchScrape/index.ts`, [[2]](diffhunk://#diff-54e790af5d84bf6683080cedf2b41153f48c57a9ab141253c2580a20b703eaeeR1-R75); `nodes/Firecrawl/api/getBatchScrapeErrors/index.ts`, [[3]](diffhunk://#diff-f60d7635ce8dafb7ea0d7f3f4c83273c113b056d49ad83150ae86a020ba612e5R1-R75)

### Crawl job management enhancements

* Added operations to cancel individual crawl jobs (`cancelCrawl`) and to retrieve crawl errors (`getCrawlErrors`). (`nodes/Firecrawl/api/cancelCrawl/index.ts`, [[1]](diffhunk://#diff-24cd70d013cef2a6f7c175678410cfd2ba02d955f94dbfa5feade56840646179R1-R75); `nodes/Firecrawl/api/getCrawlErrors/index.ts`, [[2]](diffhunk://#diff-b2ac69ae8eed186378e0bcc77b25a2399b171e89d7698e67aabd978d4d86f26fR1-R75)

### Integration and configuration updates

* Registered all new operations and their properties in the main API index and property lists, ensuring they are available for use in the node. (`nodes/Firecrawl/api/index.ts`, [[1]](diffhunk://#diff-2b103d47151bf686f25b9773a13f12b19dd8795ac3db2246cbdb28d11fcbb846R17-R34) [[2]](diffhunk://#diff-2b103d47151bf686f25b9773a13f12b19dd8795ac3db2246cbdb28d11fcbb846R43-R50) [[3]](diffhunk://#diff-2b103d47151bf686f25b9773a13f12b19dd8795ac3db2246cbdb28d11fcbb846R62-R69) [[4]](diffhunk://#diff-2b103d47151bf686f25b9773a13f12b19dd8795ac3db2246cbdb28d11fcbb846R116-R135) [[5]](diffhunk://#diff-2b103d47151bf686f25b9773a13f12b19dd8795ac3db2246cbdb28d11fcbb846R146-R155)
* Added a custom body property for the batch scrape operation, allowing users to send custom JSON payloads for advanced use cases. (`nodes/Firecrawl/properties.ts`, [[1]](diffhunk://#diff-7393a31dadace6d4ced646a4b5acd5282efcb5a312e8dae70bd848f4cb0e49a8R166-R205) [[2]](diffhunk://#diff-7393a31dadace6d4ced646a4b5acd5282efcb5a312e8dae70bd848f4cb0e49a8R260)



https://github.com/user-attachments/assets/16168e11-ac4d-4efd-b7b9-6803a5dfb54f


Fixes https://github.com/firecrawl/firecrawl/issues/2166