### PR TITLE
Add AI Agent tool support and enhance descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This is an n8n community node. It lets you use **[Firecrawl](https://firecrawl.d
 
 [n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/reference/license/) workflow automation platform.
 
-[Installation](#installation)  
-[Operations](#operations)  
-[Credentials](#credentials)  
-[Compatibility](#compatibility)  
-[Resources](#resources)  
+[Installation](#installation)
+[Operations](#operations)
+[AI Agent Tool Usage](#ai-agent-tool-usage)
+[Credentials](#credentials)
+[Compatibility](#compatibility)
+[Resources](#resources)
 [Version history](#version-history)  
 
 ## Installation
@@ -76,7 +77,60 @@ The **Firecrawl** node supports the following operations:
 - Get historical token usage for your team
 
 ### Team Queue Status
-- Get your team’s current queue load (waiting, active, max concurrency)
+- Get your team's current queue load (waiting, active, max concurrency)
+
+## AI Agent Tool Usage
+
+This node can be used as a tool with n8n's AI Agent node, allowing AI agents to scrape, crawl, and extract data from websites dynamically.
+
+### Requirements
+
+- **n8n version 1.79.0 or higher** is required for AI tool support
+- Set the environment variable `N8N_COMMUNITY_PACKAGES_ALLOW_TOOL_USAGE=true` to enable community nodes as AI tools
+
+### Docker Configuration
+
+```yaml
+version: '3'
+services:
+  n8n:
+    image: n8nio/n8n
+    environment:
+      - N8N_COMMUNITY_PACKAGES_ALLOW_TOOL_USAGE=true
+    ports:
+      - "5678:5678"
+    volumes:
+      - ~/.n8n:/home/node/.n8n
+```
+
+### Using with AI Agents
+
+1. Add the **AI Agent** node to your workflow
+2. Connect the **Firecrawl** node as a tool input to the AI Agent
+3. The AI agent can now dynamically decide when and how to use Firecrawl operations
+
+### Dynamic Parameters with $fromAI()
+
+When using Firecrawl as an AI tool, you can let the AI agent decide parameter values dynamically using the `$fromAI()` function. Click the "Let the model define this parameter" button next to any field to enable this feature.
+
+Example expressions:
+```javascript
+// Let AI decide the URL to scrape
+{{ $fromAI("url", "The URL to scrape", "string") }}
+
+// Let AI decide the search query
+{{ $fromAI("query", "Search query for finding relevant pages", "string") }}
+
+// Let AI decide whether to include subdomains
+{{ $fromAI("includeSubdomains", "Whether to include subdomains", "boolean", false) }}
+```
+
+### Best Practices for AI Tool Usage
+
+1. **Use clear operation names**: The AI agent uses operation descriptions to decide when to use each tool
+2. **Provide context in prompts**: When using the Extract operation, provide clear prompts to guide data extraction
+3. **Set reasonable limits**: Configure default limits to prevent excessive API usage
+4. **Use the Map operation first**: For unknown sites, use Map to discover URLs before scraping
 
 ## Credentials
 
@@ -91,9 +145,11 @@ To use the Firecrawl node, you need to:
 
 ## Compatibility
 
-- Minimum n8n version: 1.0.0
-- Tested against n8n versions: 1.0.0, 1.1.0, 1.2.0
+- **Minimum n8n version: 1.79.0** (required for AI tool support)
+- Tested against n8n versions: 1.79.0+
 - Node.js version: 18 or higher
+
+> **Note**: If you don't need AI tool support, earlier versions of n8n may work, but 1.79.0+ is recommended.
 
 ## Resources
 
@@ -102,6 +158,14 @@ To use the Firecrawl node, you need to:
 * [Firecrawl API Reference](https://docs.firecrawl.dev/api-reference/introduction)
 
 ## Version history
+
+### 1.1.0
+- **AI Agent Tool Support**: Node can now be used as a tool with n8n's AI Agent node
+  - Added `usableAsTool: true` to enable tool mode
+  - Enhanced all field descriptions for better AI context understanding
+  - Supports `$fromAI()` function for dynamic parameter values
+- Updated minimum n8n version requirement to 1.79.0
+- Improved operation descriptions for clearer AI agent decision making
 
 ### 1.0.6
 - Add support for additional Firecrawl endpoints:

--- a/nodes/Firecrawl/Firecrawl.node.ts
+++ b/nodes/Firecrawl/Firecrawl.node.ts
@@ -13,10 +13,11 @@ export class Firecrawl implements INodeType {
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Get data from Firecrawl API',
+		description: 'Scrape, crawl, map, search, and extract structured data from websites using Firecrawl API',
 		defaults: {
 			name: 'Firecrawl',
 		},
+		usableAsTool: true,
 		inputs: `={{["main"]}}`,
 		outputs: `={{["main"]}}`,
 		credentials: [

--- a/nodes/Firecrawl/api/batchScrape/index.ts
+++ b/nodes/Firecrawl/api/batchScrape/index.ts
@@ -13,7 +13,7 @@ import {
 
 // Define the operation name and display name
 export const name = 'batchScrape';
-export const displayName = 'Batch scrape multiple URLs';
+export const displayName = 'Batch scrape multiple URLs simultaneously';
 export const operationName = 'batchScrape';
 
 /**
@@ -30,16 +30,83 @@ function createParsersProperty(operationName: string): INodeProperties {
 			{
 				name: 'PDF',
 				value: 'pdf',
+				description: 'Extract PDF content as markdown (1 credit per page)',
 			},
 		],
 		default: [],
 		description:
-			'Controls how PDF files are processed during scraping. When PDF parser is enabled, the PDF content is extracted and converted to markdown format, with billing based on the number of pages (1 credit per page). When disabled, the PDF file is returned in base64 encoding with a flat rate of 1 credit total.',
+			'Enable file parsers for content extraction. Select "PDF" to extract PDF content as markdown text. Leave empty to get PDFs as base64 data.',
 		routing: {
 			request: {
 				body: {
 					parsers: '={{ $value }}',
 				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+
+						// Transform parsers to the correct API format: [{ type: "pdf" }]
+						if (body.parsers !== undefined) {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							let rawValue: any = body.parsers;
+
+							// Flatten nested arrays (handles cases like [["pdf"]] or [[["pdf"]]])
+							while (Array.isArray(rawValue) && rawValue.length === 1 && Array.isArray(rawValue[0])) {
+								rawValue = rawValue[0];
+							}
+
+							// Extract string values from the input
+							const extractStrings = (val: unknown): string[] => {
+								if (typeof val === 'string') {
+									// Try to parse as JSON first
+									try {
+										const parsed = JSON.parse(val);
+										return extractStrings(parsed);
+									} catch {
+										// Not JSON, treat as single value
+										return val.trim() ? [val.trim().toLowerCase()] : [];
+									}
+								}
+								if (Array.isArray(val)) {
+									return val.flatMap(extractStrings);
+								}
+								if (typeof val === 'object' && val !== null && 'type' in val) {
+									const typeVal = (val as { type: unknown }).type;
+									if (typeof typeVal === 'string') {
+										return [typeVal.toLowerCase()];
+									}
+								}
+								return [];
+							};
+
+							const parsersArray = extractStrings(rawValue);
+
+							// Filter to valid parser types and deduplicate
+							const validParsers = ['pdf'];
+							const uniqueParsers = [...new Set(parsersArray)].filter((p) =>
+								validParsers.includes(p),
+							);
+
+							// Remove if empty, otherwise convert to API format
+							if (uniqueParsers.length === 0) {
+								delete body.parsers;
+							} else {
+								body.parsers = uniqueParsers.map((parser) => ({ type: parser }));
+							}
+						}
+
+						return requestOptions;
+					},
+				],
 			},
 		},
 		displayOptions: {

--- a/nodes/Firecrawl/api/crawl/index.ts
+++ b/nodes/Firecrawl/api/crawl/index.ts
@@ -13,7 +13,7 @@ import {
 
 // Define the operation name and display name
 export const name = 'crawl';
-export const displayName = 'Crawl a website';
+export const displayName = 'Crawl a website and scrape all pages';
 export const operationName = 'crawl';
 
 /**
@@ -35,8 +35,8 @@ function createExcludePathsProperty(
 			multipleValues: true,
 		},
 		description:
-			'Specifies URL patterns to exclude from the crawl by comparing website paths against the provided regex patterns',
-		placeholder: 'Add path to exclude',
+			'URL path patterns to skip during crawling. Use glob patterns like "blog/*" to exclude sections. Useful for avoiding large archives, user-generated content, or irrelevant pages.',
+		placeholder: 'Add path pattern to exclude',
 		options: [
 			{
 				displayName: 'Items',
@@ -94,8 +94,8 @@ function createIncludePathsProperty(
 			multipleValues: true,
 		},
 		description:
-			'Specifies URL patterns to include in the crawl by comparing website paths against the provided regex patterns',
-		placeholder: 'Add path to include',
+			'URL path patterns to include in the crawl. Only pages matching these patterns will be scraped. Use glob patterns like "docs/*" to focus on specific sections.',
+		placeholder: 'Add path pattern to include',
 		options: [
 			{
 				displayName: 'Items',
@@ -149,7 +149,8 @@ function createLimitProperty(operationName: string): INodeProperties {
 		},
 		// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-limit
 		default: 500,
-		description: 'Max number of results to return',
+		description:
+			'Maximum number of pages to crawl. Use lower limits for testing or to stay within budget. The crawl stops when this limit is reached or all discoverable pages are processed.',
 		routing: {
 			request: {
 				body: {
@@ -183,7 +184,8 @@ function createDelayProperty(operationName: string): INodeProperties {
 			minValue: 0,
 		},
 		default: 0,
-		description: 'Delay between requests in milliseconds',
+		description:
+			'Wait time in milliseconds between scraping each page. Use to be polite to servers or avoid rate limiting. 0 means no delay between requests.',
 		routing: {
 			request: {
 				body: {
@@ -240,7 +242,7 @@ function createMaxConcurrencyProperty(operationName: string): INodeProperties {
 		// IMPORTANT: We don't support 100 concurrent scrapes, but we're setting a high default to avoid issues
 		default: 100,
 		description:
-			"Maximum number of concurrent scrapes. This parameter allows you to set a concurrency limit for this crawl. If not specified, the crawl adheres to your team's concurrency limit.",
+			'Maximum number of pages to scrape simultaneously. Higher values complete faster but may trigger rate limits on target sites. Use your team\'s plan limit by default.',
 		routing: {
 			request: {
 				body: {
@@ -271,7 +273,8 @@ function createPromptProperty(operationName: string): INodeProperties {
 		name: 'prompt',
 		type: 'string',
 		default: '',
-		description: 'Prompt to use for the crawl',
+		description:
+			'Natural language instructions to guide the crawl. Use to specify what content to focus on, pages to prioritize, or extraction goals (e.g., "Focus on product pages and pricing information").',
 		routing: {
 			request: {
 				body: {
@@ -309,7 +312,8 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				name: 'ignoreSitemap',
 				type: 'boolean',
 				default: false,
-				description: 'Whether to ignore the website sitemap when crawling',
+				description:
+					'Skip reading the website\'s sitemap.xml. Enable if the sitemap is inaccurate, outdated, or you want to discover pages through link following only.',
 				routing: {
 					request: {
 						body: {
@@ -324,7 +328,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				type: 'boolean',
 				default: false,
 				description:
-					'Whether to ignore the query parameters - not re-scrape the same path with different (or none)',
+					'Treat URLs with different query parameters as the same page. Enable to avoid duplicate scrapes of pages like /products?page=1 and /products?page=2.',
 				routing: {
 					request: {
 						body: {
@@ -338,7 +342,8 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				name: 'allowExternalLinks',
 				type: 'boolean',
 				default: false,
-				description: 'Whether to allow the crawler to follow links to external websites',
+				description:
+					'Follow links to other domains during the crawl. Use with caution as this can significantly expand the crawl scope and credit usage.',
 				routing: {
 					request: {
 						body: {
@@ -353,7 +358,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				type: 'boolean',
 				default: false,
 				description:
-					'Whether to allow the crawler to follow links to subdomains of the main domain',
+					'Include subdomains like blog.example.com or docs.example.com when crawling example.com. Enable to capture content across the entire domain ecosystem.',
 				routing: {
 					request: {
 						body: {

--- a/nodes/Firecrawl/api/extract/index.ts
+++ b/nodes/Firecrawl/api/extract/index.ts
@@ -7,7 +7,7 @@ import {
 import { buildApiProperties, createOperationNotice, createScrapeOptionsProperty } from '../common';
 
 const name = 'extract';
-const displayName = 'Extract Data';
+const displayName = 'Extract structured data from websites using AI';
 export const operationName = 'extract';
 
 /**
@@ -23,8 +23,9 @@ function createUrlsProperty(): INodeProperties {
 		typeOptions: {
 			multipleValues: true,
 		},
-		description: 'The URLs to extract data from. URLs should be in glob format.',
-		placeholder: 'Add URL',
+		description:
+			'URLs to extract data from. Supports glob patterns like "https://example.com/products/*" to extract from multiple pages matching the pattern.',
+		placeholder: 'Add URL pattern',
 		options: [
 			{
 				displayName: 'Items',
@@ -67,7 +68,8 @@ function createPromptProperty(): INodeProperties {
 		name: 'prompt',
 		type: 'string',
 		default: '',
-		description: 'Prompt to guide the extraction process',
+		description:
+			'Natural language instructions for the AI to guide data extraction. Be specific about what data you want (e.g., "Extract product names, prices, and descriptions from this e-commerce page").',
 		routing: {
 			request: {
 				body: {
@@ -97,7 +99,8 @@ function createSchemaProperty(): INodeProperties {
 		name: 'schema',
 		type: 'json',
 		default: '{\n  "property1": "string",\n  "property2": "number"\n}',
-		description: 'Schema to define the structure of the extracted data',
+		description:
+			'JSON Schema defining the structure of extracted data. Specify property names and types (string, number, boolean, array, object). The AI will extract data matching this schema.',
 		routing: {
 			request: {
 				body: {
@@ -123,7 +126,8 @@ function createEnableWebSearchProperty(): INodeProperties {
 		name: 'enableWebSearch',
 		type: 'boolean',
 		default: false,
-		description: 'Whether to enable web search to find additional data',
+		description:
+			'Allow the AI to search the web for additional information not found on the page. Useful for enriching extracted data with external context.',
 		routing: {
 			request: {
 				body: {
@@ -149,7 +153,8 @@ function createIgnoreSitemapProperty(): INodeProperties {
 		name: 'ignoreSitemap',
 		type: 'boolean',
 		default: true,
-		description: 'Whether to ignore the website sitemap when crawling',
+		description:
+			'Skip the sitemap when discovering URLs matching your glob pattern. Enable for faster extraction when you know the exact URL patterns you want.',
 		routing: {
 			request: {
 				body: {
@@ -175,7 +180,8 @@ function createIncludeSubdomainsProperty(): INodeProperties {
 		name: 'includeSubdomains',
 		type: 'boolean',
 		default: false,
-		description: 'Whether to include subdomains of the website',
+		description:
+			'Extract data from subdomains matching your URL patterns. Enable to include blog.example.com or docs.example.com when extracting from example.com.',
 		routing: {
 			request: {
 				body: {
@@ -201,7 +207,8 @@ function createShowSourcesProperty(): INodeProperties {
 		name: 'showSources',
 		type: 'boolean',
 		default: false,
-		description: 'Whether to show the sources used to extract the data',
+		description:
+			'Include source URLs and page sections where each piece of data was found. Useful for verification, citation, or debugging extraction results.',
 		routing: {
 			request: {
 				body: {

--- a/nodes/Firecrawl/api/map/index.ts
+++ b/nodes/Firecrawl/api/map/index.ts
@@ -8,7 +8,7 @@ import { buildApiProperties, createOperationNotice, createUrlProperty } from '..
 
 // Define the operation name and display name
 export const name = 'map';
-export const displayName = 'Map a website and get urls';
+export const displayName = 'Map a website to discover all URLs';
 export const operationName = 'map';
 
 function createSitemapProperty(): INodeProperties {
@@ -20,21 +20,22 @@ function createSitemapProperty(): INodeProperties {
 			{
 				name: 'Include',
 				value: 'include',
-				description: 'Include sitemap when crawling (default)',
+				description: 'Use sitemap plus link discovery (default, most comprehensive)',
 			},
 			{
 				name: 'Only',
 				value: 'only',
-				description: 'Only return links found in the website sitemap',
+				description: 'Only return URLs from sitemap.xml (fastest, but may miss pages)',
 			},
 			{
 				name: 'Skip',
 				value: 'skip',
-				description: 'Ignore the website sitemap when crawling',
+				description: 'Ignore sitemap, discover pages through links only',
 			},
 		],
 		default: 'include',
-		description: 'How to handle the website sitemap during crawling',
+		description:
+			'Control how URLs are discovered. "Include" combines sitemap with link crawling for best coverage. "Only" is fastest but limited to sitemap. "Skip" relies purely on link following.',
 		routing: {
 			request: {
 				body: {
@@ -60,7 +61,8 @@ function createIncludeSubdomainsProperty(): INodeProperties {
 		name: 'includeSubdomains',
 		type: 'boolean',
 		default: false,
-		description: 'Whether to include subdomains of the website',
+		description:
+			'Discover URLs on subdomains like blog.example.com or docs.example.com. Enable to map the entire domain ecosystem, not just the main domain.',
 		routing: {
 			request: {
 				body: {
@@ -92,7 +94,8 @@ function createLimitProperty(): INodeProperties {
 		},
 		// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-limit
 		default: 5000,
-		description: 'Max number of results to return',
+		description:
+			'Maximum number of URLs to return. Large sites may have thousands of pages. Use lower limits for initial exploration or to reduce response size.',
 		routing: {
 			request: {
 				body: {
@@ -118,7 +121,8 @@ function createTimeoutProperty(): INodeProperties {
 		name: 'timeout',
 		type: 'number',
 		default: 10000,
-		description: 'Timeout in milliseconds for the request',
+		description:
+			'Maximum time in milliseconds to wait for URL discovery. Increase for large sites or slow connections. Default 10000ms (10 seconds).',
 		routing: {
 			request: {
 				body: {

--- a/nodes/Firecrawl/api/search/index.ts
+++ b/nodes/Firecrawl/api/search/index.ts
@@ -9,7 +9,7 @@ import { createOperationNotice } from '../common';
 
 // Define the operation name and display name
 export const name = 'search';
-export const displayName = 'Search and optionally scrape search results';
+export const displayName = 'Search the web and scrape results';
 export const operationName = 'search';
 
 /**
@@ -22,7 +22,8 @@ function createQueryProperty(operationName: string): INodeProperties {
 		type: 'string',
 		default: '',
 		required: true,
-		description: 'The search query',
+		description:
+			'The search query to find relevant web pages. Use natural language like you would in a search engine. Results are scraped and returned with their content.',
 		routing: {
 			request: {
 				body: {
@@ -51,7 +52,8 @@ function createLimitProperty(operationName: string): INodeProperties {
 		},
 		// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-limit
 		default: 5,
-		description: 'Max number of results to return',
+		description:
+			'Maximum number of search results to return and scrape. Higher limits provide more comprehensive results but use more credits. Range: 1-100.',
 		routing: {
 			request: {
 				body: {
@@ -88,18 +90,22 @@ function createSourcesProperty(
 			{
 				name: 'Web',
 				value: 'web',
+				description: 'Search general web pages',
 			},
 			{
 				name: 'Images',
 				value: 'images',
+				description: 'Search for images',
 			},
 			{
 				name: 'News',
 				value: 'news',
+				description: 'Search news articles',
 			},
 		],
 		default: ['web'],
-		description: 'Specifies the sources to search from. At least one source must be selected.',
+		description:
+			'Types of content to search. Web returns general pages, News focuses on recent articles, Images finds visual content. Select at least one source.',
 		routing: {
 			request: {
 				body: {
@@ -151,7 +157,8 @@ function createTimeBasedSearchProperty(operation: string): INodeProperties {
 		name: 'tbs',
 		type: 'string',
 		default: '',
-		description: 'Time-based search parameter',
+		description:
+			'Filter results by time. Use "qdr:h" for past hour, "qdr:d" for past day, "qdr:w" for past week, "qdr:m" for past month, "qdr:y" for past year. Leave empty for all time.',
 		routing: {
 			request: {
 				body: {
@@ -244,7 +251,8 @@ function createTimeoutProperty(operationName: string): INodeProperties {
 		name: 'timeout',
 		type: 'number',
 		default: 60000,
-		description: 'Timeout in milliseconds for the request',
+		description:
+			'Maximum time in milliseconds to wait for search results and scraping to complete. Increase for more results or slow connections. Default 60000ms (60 seconds).',
 		routing: {
 			request: {
 				body: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "1.0.6",
-  "description": "Firecrawl node for n8n",
+  "version": "1.1.0",
+  "description": "Official Firecrawl nodes for n8n - scrape, crawl, map, search, and extract data from websites. Supports AI Agent tool usage.",
   "keywords": [
     "n8n-community-node-package"
   ],
@@ -45,7 +45,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": ">=1.79.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Enable Firecrawl node to be used as an AI Agent tool in n8n by setting usableAsTool: true and updating documentation with AI tool usage instructions. Improve all operation and parameter descriptions for better clarity and AI context, add dynamic parameter support with $fromAI(), and update minimum n8n version to 1.79.0. Refactor batch and scrape URL handling, enhance parser and output format logic, and update package metadata for version 1.1.0.

<img width="3804" height="1980" alt="image" src="https://github.com/user-attachments/assets/34d5cf5d-b42a-4824-b15a-7f88496dc498" />

Batch Scrape node Fix:

<img width="595" height="600" alt="image" src="https://github.com/user-attachments/assets/cd8b661d-5345-4161-90bb-675da566b741" />
