### PR TITLE
Refactor boolean property descriptions for clarity

### DIFF
--- a/nodes/Firecrawl/api/batchScrape/index.ts
+++ b/nodes/Firecrawl/api/batchScrape/index.ts
@@ -57,8 +57,7 @@ function createParsersProperty(operationName: string): INodeProperties {
 
 						// Transform parsers to the correct API format: [{ type: "pdf" }]
 						if (body.parsers !== undefined) {
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
-							let rawValue: any = body.parsers;
+							let rawValue = body.parsers as unknown;
 
 							// Flatten nested arrays (handles cases like [["pdf"]] or [[["pdf"]]])
 							while (Array.isArray(rawValue) && rawValue.length === 1 && Array.isArray(rawValue[0])) {

--- a/nodes/Firecrawl/api/common.ts
+++ b/nodes/Firecrawl/api/common.ts
@@ -852,7 +852,7 @@ function createBatchSpecificProperties(): INodeProperties[] {
 			type: 'boolean',
 			default: true,
 			description:
-				'Continue processing valid URLs even if some are malformed or inaccessible. When disabled, the entire batch fails if any URL is invalid.',
+				'Whether to continue processing valid URLs even if some are malformed or inaccessible. When disabled, the entire batch fails if any URL is invalid.',
 		},
 		{
 			displayName: 'Store In Cache',
@@ -860,7 +860,7 @@ function createBatchSpecificProperties(): INodeProperties[] {
 			type: 'boolean',
 			default: true,
 			description:
-				'Cache scraped pages for faster subsequent requests. Disable for privacy-sensitive scraping or when you need fresh data on every request.',
+				'Whether to cache scraped pages for faster subsequent requests. Disable for privacy-sensitive scraping or when you need fresh data on every request.',
 		},
 		{
 			displayName: 'Zero Data Retention',
@@ -868,7 +868,7 @@ function createBatchSpecificProperties(): INodeProperties[] {
 			type: 'boolean',
 			default: false,
 			description:
-				'Delete all scraped data from Firecrawl servers immediately after returning results. Enable for maximum privacy compliance (GDPR, HIPAA). Requires special account access.',
+				'Whether to delete all scraped data from Firecrawl servers immediately after returning results. Enable for maximum privacy compliance (GDPR, HIPAA). Requires special account access.',
 		},
 	];
 }
@@ -1119,7 +1119,7 @@ export function createScrapeOptionsProperty(
 						type: 'boolean',
 						default: true,
 						description:
-							'When enabled, automatically removes navigation, headers, footers, sidebars, and other boilerplate content. Best for extracting article text or primary page content. Disable to capture the full page.',
+							'Whether to automatically remove navigation, headers, footers, sidebars, and other boilerplate content. Best for extracting article text or primary page content. Disable to capture the full page.',
 					},
 					createIncludeTagsProperty(operationName, true, useNestedScrapeOptions),
 					createExcludeTagsProperty(operationName, true, useNestedScrapeOptions),
@@ -1161,7 +1161,7 @@ export function createScrapeOptionsProperty(
 						type: 'boolean',
 						default: false,
 						description:
-							'Emulate a mobile device when scraping. Useful for sites with mobile-specific content, responsive layouts, or mobile-only features. Changes viewport and user-agent.',
+							'Whether to emulate a mobile device when scraping. Useful for sites with mobile-specific content, responsive layouts, or mobile-only features. Changes viewport and user-agent.',
 					},
 					{
 						displayName: 'Skip TLS Verification',
@@ -1169,7 +1169,7 @@ export function createScrapeOptionsProperty(
 						type: 'boolean',
 						default: false,
 						description:
-							'Bypass SSL/TLS certificate validation. Enable for sites with self-signed or expired certificates. Use with caution as it reduces security.',
+							'Whether to bypass SSL/TLS certificate validation. Enable for sites with self-signed or expired certificates. Use with caution as it reduces security.',
 					},
 					{
 						displayName: 'Timeout (Ms)',
@@ -1187,7 +1187,7 @@ export function createScrapeOptionsProperty(
 						type: 'boolean',
 						default: true,
 						description:
-							'Strip embedded base64 images from output while preserving alt text. Reduces output size significantly. Disable if you need inline image data.',
+							'Whether to strip embedded base64 images from output while preserving alt text. Reduces output size significantly. Disable if you need inline image data.',
 					},
 					{
 						displayName: 'Block Ads',
@@ -1195,7 +1195,7 @@ export function createScrapeOptionsProperty(
 						type: 'boolean',
 						default: true,
 						description:
-							'Enable ad-blocking and cookie consent popup blocking for cleaner content extraction. Recommended for most scraping tasks.',
+							'Whether to enable ad-blocking and cookie consent popup blocking for cleaner content extraction. Recommended for most scraping tasks.',
 					},
 					{
 						displayName: 'Store In Cache',
@@ -1203,7 +1203,7 @@ export function createScrapeOptionsProperty(
 						type: 'boolean',
 						default: true,
 						description:
-							'Cache the scraped page for faster subsequent requests. Disable for real-time data needs, sensitive content, or when privacy is a concern.',
+							'Whether to cache the scraped page for faster subsequent requests. Disable for real-time data needs, sensitive content, or when privacy is a concern.',
 					},
 					{
 						displayName: 'Proxy',

--- a/nodes/Firecrawl/api/crawl/index.ts
+++ b/nodes/Firecrawl/api/crawl/index.ts
@@ -313,7 +313,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				type: 'boolean',
 				default: false,
 				description:
-					'Skip reading the website\'s sitemap.xml. Enable if the sitemap is inaccurate, outdated, or you want to discover pages through link following only.',
+					'Whether to skip reading the website\'s sitemap.xml. Enable if the sitemap is inaccurate, outdated, or you want to discover pages through link following only.',
 				routing: {
 					request: {
 						body: {
@@ -328,7 +328,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				type: 'boolean',
 				default: false,
 				description:
-					'Treat URLs with different query parameters as the same page. Enable to avoid duplicate scrapes of pages like /products?page=1 and /products?page=2.',
+					'Whether to treat URLs with different query parameters as the same page. Enable to avoid duplicate scrapes of pages like /products?page=1 and /products?page=2.',
 				routing: {
 					request: {
 						body: {
@@ -343,7 +343,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				type: 'boolean',
 				default: false,
 				description:
-					'Follow links to other domains during the crawl. Use with caution as this can significantly expand the crawl scope and credit usage.',
+					'Whether to follow links to other domains during the crawl. Use with caution as this can significantly expand the crawl scope and credit usage.',
 				routing: {
 					request: {
 						body: {
@@ -358,7 +358,7 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 				type: 'boolean',
 				default: false,
 				description:
-					'Include subdomains like blog.example.com or docs.example.com when crawling example.com. Enable to capture content across the entire domain ecosystem.',
+					'Whether to include subdomains like blog.example.com or docs.example.com when crawling example.com. Enable to capture content across the entire domain ecosystem.',
 				routing: {
 					request: {
 						body: {

--- a/nodes/Firecrawl/api/extract/index.ts
+++ b/nodes/Firecrawl/api/extract/index.ts
@@ -128,7 +128,7 @@ function createEnableWebSearchProperty(): INodeProperties {
 		type: 'boolean',
 		default: false,
 		description:
-			'Allow the AI to search the web for additional information not found on the page. Useful for enriching extracted data with external context.',
+			'Whether to allow the AI to search the web for additional information not found on the page. Useful for enriching extracted data with external context.',
 		routing: {
 			request: {
 				body: {
@@ -155,7 +155,7 @@ function createIgnoreSitemapProperty(): INodeProperties {
 		type: 'boolean',
 		default: true,
 		description:
-			'Skip the sitemap when discovering URLs matching your glob pattern. Enable for faster extraction when you know the exact URL patterns you want.',
+			'Whether to skip the sitemap when discovering URLs matching your glob pattern. Enable for faster extraction when you know the exact URL patterns you want.',
 		routing: {
 			request: {
 				body: {
@@ -182,7 +182,7 @@ function createIncludeSubdomainsProperty(): INodeProperties {
 		type: 'boolean',
 		default: false,
 		description:
-			'Extract data from subdomains matching your URL patterns. Enable to include blog.example.com or docs.example.com when extracting from example.com.',
+			'Whether to extract data from subdomains matching your URL patterns. Enable to include blog.example.com or docs.example.com when extracting from example.com.',
 		routing: {
 			request: {
 				body: {
@@ -209,7 +209,7 @@ function createShowSourcesProperty(): INodeProperties {
 		type: 'boolean',
 		default: false,
 		description:
-			'Include source URLs and page sections where each piece of data was found. Useful for verification, citation, or debugging extraction results.',
+			'Whether to include source URLs and page sections where each piece of data was found. Useful for verification, citation, or debugging extraction results.',
 		routing: {
 			request: {
 				body: {

--- a/nodes/Firecrawl/api/map/index.ts
+++ b/nodes/Firecrawl/api/map/index.ts
@@ -63,7 +63,7 @@ function createIncludeSubdomainsProperty(): INodeProperties {
 		type: 'boolean',
 		default: false,
 		description:
-			'Discover URLs on subdomains like blog.example.com or docs.example.com. Enable to map the entire domain ecosystem, not just the main domain.',
+			'Whether to discover URLs on subdomains like blog.example.com or docs.example.com. Enable to map the entire domain ecosystem, not just the main domain.',
 		routing: {
 			request: {
 				body: {

--- a/nodes/Firecrawl/api/scrape/index.ts
+++ b/nodes/Firecrawl/api/scrape/index.ts
@@ -57,8 +57,7 @@ function createParsersProperty(operationName: string): INodeProperties {
 
 						// Transform parsers to the correct API format: [{ type: "pdf" }]
 						if (body.parsers !== undefined) {
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
-							let rawValue: any = body.parsers;
+							let rawValue = body.parsers as unknown;
 
 							// Flatten nested arrays (handles cases like [["pdf"]] or [[["pdf"]]])
 							while (Array.isArray(rawValue) && rawValue.length === 1 && Array.isArray(rawValue[0])) {

--- a/nodes/Firecrawl/properties.ts
+++ b/nodes/Firecrawl/properties.ts
@@ -18,28 +18,28 @@ export const resourceSelect: INodeProperties[] = [
 		noDataExpression: true,
 		options: [
 			{
-				name: 'Scraping',
-				value: 'Scraping',
-			},
-			{
-				name: 'Crawling',
-				value: 'Crawling',
+				name: 'Account',
+				value: 'Account',
 			},
 			{
 				name: 'Agent',
 				value: 'Agent',
 			},
 			{
-				name: 'Map & Search',
-				value: 'MapSearch',
-			},
-			{
-				name: 'Account',
-				value: 'Account',
+				name: 'Crawling',
+				value: 'Crawling',
 			},
 			{
 				name: 'Extract (Legacy)',
 				value: 'Extract',
+			},
+			{
+				name: 'Map & Search',
+				value: 'MapSearch',
+			},
+			{
+				name: 'Scraping',
+				value: 'Scraping',
 			},
 		],
 		default: 'Scraping',


### PR DESCRIPTION
Updated descriptions of boolean properties across Firecrawl modules to use 'Whether to...' phrasing for improved clarity and consistency. Also reordered options in resourceSelect for better logical grouping. Minor type annotation cleanup in parser property handling.