### PR TITLE
chore: bump version to 2.1.2 and update publish workflow

### DIFF
--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -11,6 +11,9 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
@@ -23,6 +26,6 @@ jobs:
       - name: Build
         run: npm run build
       - name: Publish
-        run: npm publish --access public
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/nodes/Firecrawl/api/agent/index.ts
+++ b/nodes/Firecrawl/api/agent/index.ts
@@ -367,7 +367,6 @@ options.routing = {
 				const jobId = responseBody.id as string;
 				const credentials = await this.getCredentials('firecrawlApi');
 				const baseUrl = (credentials.baseUrl as string) || 'https://api.firecrawl.dev/v2';
-				const apiKey = credentials.apiKey as string;
 
 				// Get max wait time from node parameter (in seconds), convert to ms
 				const maxWaitTimeSeconds = this.getNodeParameter('maxWaitTime', DEFAULT_MAX_WAIT_TIME_SECONDS) as number;
@@ -405,15 +404,18 @@ options.routing = {
 
 					for (let attempt = 0; attempt < MAX_POLL_RETRIES; attempt++) {
 						try {
-							statusResponse = await this.helpers.httpRequest({
-								method: 'GET',
-								url: `${baseUrl}/agent/${jobId}`,
-								headers: {
-									Authorization: `Bearer ${apiKey}`,
-									Accept: 'application/json',
+							statusResponse = await this.helpers.httpRequestWithAuthentication.call(
+								this,
+								'firecrawlApi',
+								{
+									method: 'GET',
+									url: `${baseUrl}/agent/${jobId}`,
+									headers: {
+										Accept: 'application/json',
+									},
+									json: true,
 								},
-								json: true,
-							});
+							);
 							break; // Success, exit retry loop
 						} catch (error) {
 							lastError = error as Error;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Official Firecrawl nodes for n8n - scrape, crawl, map, search, and extract data from websites. Supports AI Agent tool usage.",
   "keywords": [
     "n8n-community-node-package"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mendableai/n8n-nodes-firecrawl.git"
+    "url": "git+https://github.com/firecrawl/n8n-nodes-firecrawl.git"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Updated package version in package.json to 2.1.2.
- Modified GitHub Actions workflow to include permissions for contents and id-token.
- Changed npm publish command to include provenance flag for better package integrity.