### PR TITLE
feat: expand node description to cover all supported actions

### DIFF
--- a/nodes/Firecrawl/Firecrawl.node.ts
+++ b/nodes/Firecrawl/Firecrawl.node.ts
@@ -13,7 +13,8 @@ export class Firecrawl implements INodeType {
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Scrape, crawl, map, search, and extract structured data from websites using Firecrawl API',
+		description:
+			'Scrape, crawl, map, search, and extract structured data from websites, run AI web agents, control browser sessions and interactions, and track account usage with the Firecrawl API',
 		defaults: {
 			name: 'Firecrawl',
 		},


### PR DESCRIPTION
## What

Expands the Firecrawl node's `description` field so it reflects every resource the node supports.

Before:
> Scrape, crawl, map, search, and extract structured data from websites using Firecrawl API

After:
> Scrape, crawl, map, search, and extract structured data from websites, run AI web agents, control browser sessions and interactions, and track account usage with the Firecrawl API

## Why

The node currently ships with eight resource groups — Scraping, Crawling, Agent, Map & Search, Account, Browser, Interact and Extract (Legacy) — but the description only mentioned five of them. The node `description` is what surfaces in the n8n Nodes panel and is used by AI-assisted node search, so an incomplete description makes the node harder to discover and undersells its capabilities (AI agents, browser sessions, interactions, account/usage).

This is a copy-only change to a single string; no behavior changes.

## How it was tested

- `npm run build` — passes
- `npm run lint` — passes

Made with [Cursor](https://cursor.com)