### PR TITLE
feat: add search aliases for improved node discoverability

### DIFF
--- a/nodes/Firecrawl/Firecrawl.node.json
+++ b/nodes/Firecrawl/Firecrawl.node.json
@@ -27,6 +27,7 @@
 	"web scrape",
 	"web scraper",
 	"web scraping",
+	"webscrape",
 	"web crawl",
 	"web crawler",
 	"web crawling",


### PR DESCRIPTION
Adds `webscrape` to the node's `codex.alias` list (alongside the existing scrape/search/serp/fetch aliases) so it surfaces for that search term in the n8n nodes/tools search panel.

Made with [Cursor](https://cursor.com)