### PR TITLE
fix(scrape-options): stop raw fixedCollection values leaking into request body

### DIFF
--- a/nodes/Firecrawl/api/common.ts
+++ b/nodes/Firecrawl/api/common.ts
@@ -233,6 +233,14 @@ export function createUrlProperty(
 }
 
 /**
+ * Turns an `includeTags`/`excludeTags` fixedCollection into the string array the API
+ * expects. Blank rows are dropped, and the field is omitted entirely when no tag is
+ * configured rather than sending an empty array.
+ */
+const TAGS_EXPRESSION =
+	'={{Array.isArray($value.items) && $value.items.some(item => item.tag) ? $value.items.map(item => item.tag).filter(tag => tag) : undefined}}';
+
+/**
  * Creates the actions property
  * @param operationName - The name of the operation
  * @param omitDisplayOptions - Whether to omit the display options
@@ -250,7 +258,7 @@ export function createActionsProperty(
 		displayName: 'Actions',
 		name: 'actions',
 		type: 'fixedCollection',
-		default: [],
+		default: {},
 		typeOptions: {
 			multipleValues: true,
 		},
@@ -565,11 +573,11 @@ export function createIncludeTagsProperty(
 				body: useNestedScrapeOptions
 					? {
 							scrapeOptions: {
-								includeTags: '={{$value.items ? $value.items.map(item => item.tag) : []}}',
+								includeTags: TAGS_EXPRESSION,
 							},
 					  }
 					: {
-							includeTags: '={{$value.items ? $value.items.map(item => item.tag) : []}}',
+							includeTags: TAGS_EXPRESSION,
 					  },
 			},
 		},
@@ -705,11 +713,11 @@ export function createExcludeTagsProperty(
 				body: useNestedScrapeOptions
 					? {
 							scrapeOptions: {
-								excludeTags: '={{$value.items ? $value.items.map(item => item.tag) : []}}',
+								excludeTags: TAGS_EXPRESSION,
 							},
 					  }
 					: {
-							excludeTags: '={{$value.items ? $value.items.map(item => item.tag) : []}}',
+							excludeTags: TAGS_EXPRESSION,
 					  },
 			},
 		},
@@ -873,15 +881,41 @@ function createBatchSpecificProperties(): INodeProperties[] {
 	];
 }
 
+/**
+ * Options inside the scrape options collection that define their own `routing`.
+ *
+ * Their raw n8n value is a `fixedCollection` wrapper (`{ format: [...] }`,
+ * `{ items: [...] }`, `{ settings: {...} }` or `{}` when untouched), not the shape the
+ * API expects. Each of them already serialises itself through its own routing, so the
+ * raw value must be stripped from the collection before it is spread into the request
+ * body - otherwise it leaks through and the API rejects the request with a 400
+ * ("expected array, received object").
+ */
+const SELF_ROUTED_SCRAPE_OPTIONS = [
+	'formats',
+	'includeTags',
+	'excludeTags',
+	'actions',
+	'location',
+	'webhook',
+];
+
 export function createScrapeOptionsProperty(
 	operationName: string,
 	useNestedScrapeOptions: boolean = true,
 	batchMode: boolean = false,
 	resourceName: string = 'Scraping',
 ): INodeProperties {
+	const rawScrapeOptions = `={{Object.fromEntries(Object.entries($value.options || {}).filter(([k]) => !${JSON.stringify(
+		SELF_ROUTED_SCRAPE_OPTIONS,
+	)}.includes(k)))}}`;
 	const scrapeOptionsBody = useNestedScrapeOptions
-		? { scrapeOptions: '={{$value.options}}' }
-		: '={{Object.fromEntries(Object.entries($value.options || {}).filter(([k]) => k !== "webhook"))}}';
+		? { scrapeOptions: rawScrapeOptions }
+		: rawScrapeOptions;
+	// Turns the `formats` fixedCollection into the array the API expects. Omitted entirely
+	// when no format is configured so the API falls back to its own default.
+	const formatsExpression =
+		'={{Array.isArray($value.format) && $value.format.length > 0 ? $value.format.map(f => { if (f.type === "json" || f.type === "changeTracking") { const format = { type: f.type }; if (f.prompt) format.prompt = f.prompt; if (f.schema) { const schema = JSON.parse(f.schema); if (Object.keys(schema).length > 0) format.schema = schema; } if (f.modes) format.modes = f.modes; if (f.tag) format.tag = f.tag; return format; } else if (f.type === "screenshot") { const format = { type: f.type }; if (f.fullPage !== undefined) format.fullPage = f.fullPage; if (f.quality !== undefined && f.quality !== "" && f.quality !== null) format.quality = f.quality; if (f.viewportWidth !== undefined && f.viewportWidth !== "" && f.viewportWidth !== null && f.viewportHeight !== undefined && f.viewportHeight !== "" && f.viewportHeight !== null) { format.viewport = { width: f.viewportWidth, height: f.viewportHeight }; } return format; } else { return f.type; } }) : undefined}}';
 	return {
 		displayName: 'Scrape Options',
 		name: 'scrapeOptions',
@@ -898,7 +932,7 @@ export function createScrapeOptionsProperty(
 						displayName: 'Formats',
 						name: 'formats',
 						type: 'fixedCollection',
-						default: [{ type: 'markdown' }],
+						default: { format: [{ type: 'markdown' }] },
 						typeOptions: {
 							multipleValues: true,
 						},
@@ -1106,10 +1140,9 @@ export function createScrapeOptionsProperty(
 						],
 						routing: {
 							request: {
-								body: {
-									formats:
-										'={{$value.format ? $value.format.map(f => { if (f.type === "json" || f.type === "changeTracking") { const format = { type: f.type }; if (f.prompt) format.prompt = f.prompt; if (f.schema) format.schema = JSON.parse(f.schema); if (f.modes) format.modes = f.modes; if (f.tag) format.tag = f.tag; return format; } else if (f.type === "screenshot") { const format = { type: f.type }; if (f.fullPage !== undefined) format.fullPage = f.fullPage; if (f.quality !== undefined && f.quality !== "" && f.quality !== null) format.quality = f.quality; if (f.viewportWidth !== undefined && f.viewportWidth !== "" && f.viewportWidth !== null && f.viewportHeight !== undefined && f.viewportHeight !== "" && f.viewportHeight !== null) { format.viewport = { width: f.viewportWidth, height: f.viewportHeight }; } return format; } else { return f.type; } }) : []}}',
-								},
+								body: useNestedScrapeOptions
+									? { scrapeOptions: { formats: formatsExpression } }
+									: { formats: formatsExpression },
 							},
 						},
 					},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Official Firecrawl nodes for n8n - scrape, crawl, map, search, and extract data from websites. Supports AI Agent tool usage.",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
Fixes #41, fixes #42, fixes #17.

## The bug

Merely opening **Scrape Options** on `/scrape` breaks every request:

```json
{ "success": false, "code": "BAD_REQUEST", "error": "Bad Request",
  "details": [{ "expected": "array", "code": "invalid_type", "path": ["actions"],
                "message": "Invalid input: expected array, received object" }] }
```

Leaving Scrape Options untouched works fine, which is what made this look like a
"formats dropdown" problem — the formats dropdown is just the reason people open
the collection in the first place.

## Root cause

`createScrapeOptionsProperty` spreads the collection's **raw** n8n value into the
request body:

```ts
'={{Object.fromEntries(Object.entries($value.options || {}).filter(([k]) => k !== "webhook"))}}'
```

Six of those options (`formats`, `includeTags`, `excludeTags`, `actions`,
`location`, `webhook`) are `fixedCollection`s. n8n stores them as wrapper objects
— `{ format: [...] }`, `{ items: [...] }`, `{ settings: {...} }`, or `{}` when
untouched — not as the arrays the API expects. Opening the collection
materialises every field at its default, so the wrappers get spread verbatim into
the body.

Each of those options does define its own `routing` to convert the wrapper into
the right shape, but that correction cannot land. n8n merges routing
contributions with lodash `merge`, and `assignMergeValue` skips an `undefined`
source when the key already exists on the destination. So the `undefined` that
`actions` returns when unset never overwrites the leaked `{}`.

That also explains why #40 turned this from a latent bug into a hard failure:
changing the fallback from `[]` to `undefined` was correct in isolation, but it
removed the empty array that had been masking the leak. Hence the
v2.0.6 → v2.1.1 regression reported in #41.

`/crawl` and `/extract` (#17) hit a second, independent bug: the `formats`
routing always wrote to the **top level** of the body, ignoring
`useNestedScrapeOptions`. That produced both an `unrecognized_keys: ["formats"]`
error and an unconverted `scrapeOptions.formats` object in the same request.

## The fix

- **Strip self-routed options from the raw spread** so each is serialised only by
  its own routing. This is the core fix.
- **Route `formats` under `scrapeOptions`** when the operation nests them
  (`/crawl`, `/extract`).
- **Omit `formats` / `includeTags` / `excludeTags` when unset** instead of sending
  empty arrays, and drop blank tag rows.
- **Skip the JSON / changeTracking `schema` when it is still the empty `{}`
  default**, which the API rejects.
- **Correct the `actions` and `formats` fixedCollection defaults**, declared in the
  wrong shape (`[]` and `[{ type: 'markdown' }]`) — the same class of bug.

## Verification

`tsc`, `eslint` and `npm run build` are clean. Beyond that I simulated n8n's
`RoutingNode` body construction (own routing first, then children, lodash-merged)
against the built properties, for the exact configurations in the issues.

Before, with Scrape Options merely opened, `/scrape` sent:

```json
{ "url": "...", "formats": [{ "type": "markdown" }], "includeTags": [],
  "excludeTags": [], "actions": [], "location": {}, ... }
```

`location: {}` there is the leak caught in the act — its routing returns
`undefined` when unset, exactly like `actions`, yet the raw `{}` survives the
merge. `formats` is likewise the wrong shape.

After:

```json
{ "url": "...", "formats": ["markdown"], "onlyMainContent": true,
  "headers": {}, "waitFor": 0, "timeout": 30000, "proxy": "basic", ... }
```

`/crawl` now nests correctly, with no stray top-level `formats`:

```json
{ "url": "...", "scrapeOptions": { "formats": ["markdown"], "onlyMainContent": true, ... } }
```

And configured values still serialise properly:

```json
{ "formats": ["html", "links", { "type": "json", "prompt": "extract the title" }],
  "includeTags": ["article"], "excludeTags": ["nav"],
  "actions": [{ "type": "wait", "milliseconds": 2000 },
              { "type": "click", "selector": "#more" }],
  "location": { "country": "DE", "languages": ["de"] } }
```

I have not exercised this against a live n8n instance, so a manual pass on
`/scrape`, `/crawl` and `/batch/scrape` before release is worth doing.

## Note on a separate bug

`scrapeOptions.headers` is a `collection` with `key` / `value` fields, so adding a
header yields `{"key": "X", "value": "Y"}` rather than `{"X": "Y"}`. Harmless at
its `{}` default and untouched here, but it needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
