### PR TITLE
chore: add bugs URL and re-trigger the 2.1.3 publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/firecrawl/n8n-nodes-firecrawl.git"
   },
+  "bugs": {
+    "url": "https://github.com/firecrawl/n8n-nodes-firecrawl/issues"
+  },
   "main": "index.js",
   "scripts": {
     "build": "tsc && gulp build:icons",


### PR DESCRIPTION
The 2.1.3 publish failed at the registry write, so the version bump merged in
#46 never shipped — npm is still on `2.1.2` and the scrape-options fix is not
out there.

[The publish workflow](.github/workflows/publish-js-sdk.yml) only runs on pushes
to `master` that touch `package.json`, so re-releasing needs a change to that
file. This adds the `bugs` field, which npm renders as the "Report issues" link
on the package page — a small real improvement rather than stray whitespace.

Version stays at **2.1.3**. That version was never claimed on the registry, so
there is nothing to skip over.

Merging this should publish 2.1.3 through the new OIDC flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
