### PR TITLE
chore: remove bugs field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "type": "git",
     "url": "git+https://github.com/firecrawl/n8n-nodes-firecrawl.git"
   },
-  "bugs": {
-    "url": "https://github.com/firecrawl/n8n-nodes-firecrawl/issues"
-  },
   "main": "index.js",
   "scripts": {
     "build": "tsc && gulp build:icons",


### PR DESCRIPTION
Reverts the metadata addition from #47. Version stays at 2.1.3, which is still unclaimed on the registry.