### PR TITLE
chore: bump version to 2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "2.0.6",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendable/n8n-nodes-firecrawl",
-      "version": "2.0.6",
+      "version": "2.1.4",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/parser": "~5.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Official Firecrawl nodes for n8n - scrape, crawl, map, search, and extract data from websites. Supports AI Agent tool usage.",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
Bumps the package version to 2.1.4 to publish the `@n8n/scan-community-package` lint fixes from #49 to npm.

## Changes
- `package.json` / `package-lock.json`: 2.1.3 → 2.1.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)